### PR TITLE
WIP bpo-43892: Make match patterns explicit in AST

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -226,20 +226,20 @@ case_block[match_case_ty]:
     | invalid_case_block
 guard[expr_ty]: 'if' guard=named_expression { guard }
 
-patterns[expr_ty]:
-    | values[asdl_expr_seq*]=open_sequence_pattern {
-        _PyAST_Tuple(values, Load, EXTRA) }
+patterns[pattern_ty]:
+    | patterns[asdl_pattern_seq*]=open_sequence_pattern {
+        _PyAST_MatchSequence(patterns, EXTRA) }
     | pattern
-pattern[expr_ty]:
+pattern[pattern_ty]:
     | as_pattern
     | or_pattern
-as_pattern[expr_ty]:
-    | pattern=or_pattern 'as' target=capture_pattern {
+as_pattern[pattern_ty]:
+    | pattern=or_pattern 'as' target=pattern_capture_target {
         _PyAST_MatchAs(pattern, target->v.Name.id, EXTRA) }
-or_pattern[expr_ty]:
-    | patterns[asdl_expr_seq*]='|'.closed_pattern+ {
+or_pattern[pattern_ty]:
+    | patterns[asdl_pattern_seq*]='|'.closed_pattern+ {
         asdl_seq_LEN(patterns) == 1 ? asdl_seq_GET(patterns, 0) : _PyAST_MatchOr(patterns, EXTRA) }
-closed_pattern[expr_ty]:
+closed_pattern[pattern_ty]:
     | literal_pattern
     | capture_pattern
     | wildcard_pattern
@@ -249,27 +249,44 @@ closed_pattern[expr_ty]:
     | mapping_pattern
     | class_pattern
 
-literal_pattern[expr_ty]:
+# Literal patterns are used for equality and identity constraints
+literal_pattern[pattern_ty]:
+    | value=signed_number !('+' | '-') { _PyAST_MatchValue(value, EXTRA) }
+    | value=complex_number { _PyAST_MatchValue(value, EXTRA) }
+    | value=strings { _PyAST_MatchValue(value, EXTRA) }
+    | 'None' { _PyAST_MatchConstant(Py_None, EXTRA) }
+    | 'True' { _PyAST_MatchConstant(Py_True, EXTRA) }
+    | 'False' { _PyAST_MatchConstant(Py_False, EXTRA) }
+
+# Literal expressions are used to restrict permitted mapping pattern keys
+literal_expr[expr_ty]:
     | signed_number !('+' | '-')
-    | real=signed_number '+' imag=NUMBER { _PyAST_BinOp(real, Add, imag, EXTRA) }
-    | real=signed_number '-' imag=NUMBER  { _PyAST_BinOp(real, Sub, imag, EXTRA) }
+    | complex_number
     | strings
     | 'None' { _PyAST_Constant(Py_None, NULL, EXTRA) }
     | 'True' { _PyAST_Constant(Py_True, NULL, EXTRA) }
     | 'False' { _PyAST_Constant(Py_False, NULL, EXTRA) }
+
+complex_number[expr_ty]:
+    | real=signed_number '+' imag=NUMBER { _PyAST_BinOp(real, Add, imag, EXTRA) }
+    | real=signed_number '-' imag=NUMBER  { _PyAST_BinOp(real, Sub, imag, EXTRA) }
+
 signed_number[expr_ty]:
     | NUMBER
     | '-' number=NUMBER { _PyAST_UnaryOp(USub, number, EXTRA) }
 
-capture_pattern[expr_ty]:
+capture_pattern[pattern_ty]:
+    | target=pattern_capture_target { _PyAST_MatchAs(NULL, target->v.Name.id, EXTRA) }
+
+pattern_capture_target[expr_ty]:
     | !"_" name=NAME !('.' | '(' | '=') {
         _PyPegen_set_expr_context(p, name, Store) }
 
-wildcard_pattern[expr_ty]:
-    | "_" { _PyAST_Name(CHECK(PyObject*, _PyPegen_new_identifier(p, "_")), Store, EXTRA) }
+wildcard_pattern[pattern_ty]:
+    | "_" { _PyAST_MatchAlways(EXTRA) }
 
-value_pattern[expr_ty]:
-    | attr=attr !('.' | '(' | '=') { attr }
+value_pattern[pattern_ty]:
+    | attr=attr !('.' | '(' | '=') { _PyAST_MatchValue(attr, EXTRA) }
 attr[expr_ty]:
     | value=name_or_attr '.' attr=NAME {
         _PyAST_Attribute(value, attr->v.Name.id, Load, EXTRA) }
@@ -277,50 +294,68 @@ name_or_attr[expr_ty]:
     | attr
     | NAME
 
-group_pattern[expr_ty]:
+group_pattern[pattern_ty]:
     | '(' pattern=pattern ')' { pattern }
 
-sequence_pattern[expr_ty]:
-    | '[' values=maybe_sequence_pattern? ']' { _PyAST_List(values, Load, EXTRA) }
-    | '(' values=open_sequence_pattern? ')' { _PyAST_Tuple(values, Load, EXTRA) }
+sequence_pattern[pattern_ty]:
+    | '[' patterns=maybe_sequence_pattern? ']' { _PyAST_MatchSequence(patterns, EXTRA) }
+    | '(' patterns=open_sequence_pattern? ')' { _PyAST_MatchSequence(patterns, EXTRA) }
 open_sequence_pattern[asdl_seq*]:
-    | value=maybe_star_pattern ',' values=maybe_sequence_pattern? {
-        _PyPegen_seq_insert_in_front(p, value, values) }
+    | pattern=maybe_star_pattern ',' patterns=maybe_sequence_pattern? {
+        _PyPegen_seq_insert_in_front(p, pattern, patterns) }
 maybe_sequence_pattern[asdl_seq*]:
-    | values=','.maybe_star_pattern+ ','? { values }
-maybe_star_pattern[expr_ty]:
+    | patterns=','.maybe_star_pattern+ ','? { patterns }
+maybe_star_pattern[pattern_ty]:
     | star_pattern
     | pattern
-star_pattern[expr_ty]:
-    | '*' value=(capture_pattern | wildcard_pattern) {
-        _PyAST_Starred(value, Store, EXTRA) }
+star_pattern[pattern_ty]:
+    | '*' target=pattern_capture_target {
+        _PyAST_MatchRestOfSequence(target->v.Name.id, EXTRA) }
+    | '*' wildcard_pattern {
+        _PyAST_MatchRestOfSequence(NULL, EXTRA) }
 
-mapping_pattern[expr_ty]:
+mapping_pattern[pattern_ty]:
     | '{' items=items_pattern? '}' {
-        _PyAST_Dict(CHECK(asdl_expr_seq*, _PyPegen_get_keys(p, items)), CHECK(asdl_expr_seq*, _PyPegen_get_values(p, items)), EXTRA) }
+        _PyAST_MatchMapping(
+            CHECK(asdl_expr_seq*, _PyPegen_get_pattern_keys(p, items)),
+            CHECK(asdl_pattern_seq*, _PyPegen_get_patterns(p, items)),
+            EXTRA) }
 items_pattern[asdl_seq*]:
     | items=','.key_value_pattern+ ','? { items }
-key_value_pattern[KeyValuePair*]:
-    | key=(literal_pattern | value_pattern) ':' value=pattern {
-        _PyPegen_key_value_pair(p, key, value) }
+key_value_pattern[KeyPatternPair*]:
+    | key=(literal_expr | attr) ':' pattern=pattern {
+        _PyPegen_key_pattern_pair(p, key, pattern) }
     | double_star_pattern
-double_star_pattern[KeyValuePair*]:
-    | '**' value=capture_pattern { _PyPegen_key_value_pair(p, NULL, value) }
+double_star_pattern[KeyPatternPair*]:
+    | '**' target=pattern_capture_target {
+        _PyPegen_key_pattern_pair(p, NULL, _PyAST_MatchAs(NULL, target->v.Name.id, EXTRA)) }
 
-class_pattern[expr_ty]:
-    | func=name_or_attr '(' ')' { _PyAST_Call(func, NULL, NULL, EXTRA) }
-    | func=name_or_attr '(' args=positional_patterns ','? ')' {
-        _PyAST_Call(func, args, NULL, EXTRA) }
-    | func=name_or_attr '(' keywords=keyword_patterns ','? ')' {
-        _PyAST_Call(func, NULL, keywords, EXTRA) }
-    | func=name_or_attr '(' args=positional_patterns ',' keywords=keyword_patterns ','? ')' {
-        _PyAST_Call(func, args, keywords, EXTRA) }
-positional_patterns[asdl_expr_seq*]:
-    | args[asdl_expr_seq*]=','.pattern+ { args }
-keyword_patterns[asdl_keyword_seq*]:
-    | keywords[asdl_keyword_seq*]=','.keyword_pattern+ { keywords }
-keyword_pattern[keyword_ty]:
-    | arg=NAME '=' value=pattern { _PyAST_keyword(arg->v.Name.id, value, EXTRA) }
+class_pattern[pattern_ty]:
+    | cls=name_or_attr '(' ')' {
+        _PyAST_MatchClass(cls, NULL, NULL, NULL, EXTRA) }
+    | cls=name_or_attr '(' patterns=positional_patterns ','? ')' {
+        _PyAST_MatchClass(cls, patterns, NULL, NULL, EXTRA) }
+    | cls=name_or_attr '(' keywords=keyword_patterns ','? ')' {
+        _PyAST_MatchClass(
+            cls, NULL,
+            CHECK(asdl_identifier_seq*, _PyPegen_map_names_to_ids(p,
+                CHECK(asdl_expr_seq*, _PyPegen_get_pattern_keys(p, keywords)))),
+            CHECK(asdl_pattern_seq*, _PyPegen_get_patterns(p, keywords)),
+            EXTRA) }
+    | cls=name_or_attr '(' patterns=positional_patterns ',' keywords=keyword_patterns ','? ')' {
+        _PyAST_MatchClass(
+            cls,
+            patterns,
+            CHECK(asdl_identifier_seq*, _PyPegen_map_names_to_ids(p,
+                CHECK(asdl_expr_seq*, _PyPegen_get_pattern_keys(p, keywords)))),
+            CHECK(asdl_pattern_seq*, _PyPegen_get_patterns(p, keywords)),
+            EXTRA) }
+positional_patterns[asdl_pattern_seq*]:
+    | args[asdl_pattern_seq*]=','.pattern+ { args }
+keyword_patterns[asdl_seq*]:
+    | keywords[asdl_seq*]=','.keyword_pattern+ { keywords }
+keyword_pattern[pattern_ty]:
+    | arg=NAME '=' value=pattern { _PyPegen_key_pattern_pair(p, arg, value) }
 
 return_stmt[stmt_ty]:
     | 'return' a=[star_expressions] { _PyAST_Return(a, EXTRA) }

--- a/Include/internal/pycore_ast.h
+++ b/Include/internal/pycore_ast.h
@@ -47,6 +47,8 @@ typedef struct _withitem *withitem_ty;
 
 typedef struct _match_case *match_case_ty;
 
+typedef struct _pattern *pattern_ty;
+
 typedef struct _type_ignore *type_ignore_ty;
 
 
@@ -129,6 +131,13 @@ typedef struct {
 
 asdl_match_case_seq *_Py_asdl_match_case_seq_new(Py_ssize_t size, PyArena
                                                  *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    pattern_ty typed_elements[1];
+} asdl_pattern_seq;
+
+asdl_pattern_seq *_Py_asdl_pattern_seq_new(Py_ssize_t size, PyArena *arena);
 
 typedef struct {
     _ASDL_SEQ_HEAD
@@ -327,8 +336,7 @@ enum _expr_kind {BoolOp_kind=1, NamedExpr_kind=2, BinOp_kind=3, UnaryOp_kind=4,
                   YieldFrom_kind=15, Compare_kind=16, Call_kind=17,
                   FormattedValue_kind=18, JoinedStr_kind=19, Constant_kind=20,
                   Attribute_kind=21, Subscript_kind=22, Starred_kind=23,
-                  Name_kind=24, List_kind=25, Tuple_kind=26, Slice_kind=27,
-                  MatchAs_kind=28, MatchOr_kind=29};
+                  Name_kind=24, List_kind=25, Tuple_kind=26, Slice_kind=27};
 struct _expr {
     enum _expr_kind kind;
     union {
@@ -471,15 +479,6 @@ struct _expr {
             expr_ty step;
         } Slice;
 
-        struct {
-            expr_ty pattern;
-            identifier name;
-        } MatchAs;
-
-        struct {
-            asdl_expr_seq *patterns;
-        } MatchOr;
-
     } v;
     int lineno;
     int col_offset;
@@ -555,9 +554,61 @@ struct _withitem {
 };
 
 struct _match_case {
-    expr_ty pattern;
+    pattern_ty pattern;
     expr_ty guard;
     asdl_stmt_seq *body;
+};
+
+enum _pattern_kind {MatchAlways_kind=1, MatchValue_kind=2,
+                     MatchConstant_kind=3, MatchSequence_kind=4,
+                     MatchMapping_kind=5, MatchClass_kind=6,
+                     MatchRestOfSequence_kind=7, MatchAs_kind=8,
+                     MatchOr_kind=9};
+struct _pattern {
+    enum _pattern_kind kind;
+    union {
+        struct {
+            expr_ty value;
+        } MatchValue;
+
+        struct {
+            constant value;
+        } MatchConstant;
+
+        struct {
+            asdl_pattern_seq *patterns;
+        } MatchSequence;
+
+        struct {
+            asdl_expr_seq *keys;
+            asdl_pattern_seq *patterns;
+        } MatchMapping;
+
+        struct {
+            expr_ty cls;
+            asdl_pattern_seq *patterns;
+            asdl_identifier_seq *extra_attrs;
+            asdl_pattern_seq *extra_patterns;
+        } MatchClass;
+
+        struct {
+            identifier target;
+        } MatchRestOfSequence;
+
+        struct {
+            pattern_ty pattern;
+            identifier target;
+        } MatchAs;
+
+        struct {
+            asdl_pattern_seq *patterns;
+        } MatchOr;
+
+    } v;
+    int lineno;
+    int col_offset;
+    int end_lineno;
+    int end_col_offset;
 };
 
 enum _type_ignore_kind {TypeIgnore_kind=1};
@@ -733,11 +784,6 @@ expr_ty _PyAST_Tuple(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
 expr_ty _PyAST_Slice(expr_ty lower, expr_ty upper, expr_ty step, int lineno,
                      int col_offset, int end_lineno, int end_col_offset,
                      PyArena *arena);
-expr_ty _PyAST_MatchAs(expr_ty pattern, identifier name, int lineno, int
-                       col_offset, int end_lineno, int end_col_offset, PyArena
-                       *arena);
-expr_ty _PyAST_MatchOr(asdl_expr_seq * patterns, int lineno, int col_offset,
-                       int end_lineno, int end_col_offset, PyArena *arena);
 comprehension_ty _PyAST_comprehension(expr_ty target, expr_ty iter,
                                       asdl_expr_seq * ifs, int is_async,
                                       PyArena *arena);
@@ -760,8 +806,34 @@ alias_ty _PyAST_alias(identifier name, identifier asname, int lineno, int
                       *arena);
 withitem_ty _PyAST_withitem(expr_ty context_expr, expr_ty optional_vars,
                             PyArena *arena);
-match_case_ty _PyAST_match_case(expr_ty pattern, expr_ty guard, asdl_stmt_seq *
-                                body, PyArena *arena);
+match_case_ty _PyAST_match_case(pattern_ty pattern, expr_ty guard,
+                                asdl_stmt_seq * body, PyArena *arena);
+pattern_ty _PyAST_MatchAlways(int lineno, int col_offset, int end_lineno, int
+                              end_col_offset, PyArena *arena);
+pattern_ty _PyAST_MatchValue(expr_ty value, int lineno, int col_offset, int
+                             end_lineno, int end_col_offset, PyArena *arena);
+pattern_ty _PyAST_MatchConstant(constant value, int lineno, int col_offset, int
+                                end_lineno, int end_col_offset, PyArena *arena);
+pattern_ty _PyAST_MatchSequence(asdl_pattern_seq * patterns, int lineno, int
+                                col_offset, int end_lineno, int end_col_offset,
+                                PyArena *arena);
+pattern_ty _PyAST_MatchMapping(asdl_expr_seq * keys, asdl_pattern_seq *
+                               patterns, int lineno, int col_offset, int
+                               end_lineno, int end_col_offset, PyArena *arena);
+pattern_ty _PyAST_MatchClass(expr_ty cls, asdl_pattern_seq * patterns,
+                             asdl_identifier_seq * extra_attrs,
+                             asdl_pattern_seq * extra_patterns, int lineno, int
+                             col_offset, int end_lineno, int end_col_offset,
+                             PyArena *arena);
+pattern_ty _PyAST_MatchRestOfSequence(identifier target, int lineno, int
+                                      col_offset, int end_lineno, int
+                                      end_col_offset, PyArena *arena);
+pattern_ty _PyAST_MatchAs(pattern_ty pattern, identifier target, int lineno,
+                          int col_offset, int end_lineno, int end_col_offset,
+                          PyArena *arena);
+pattern_ty _PyAST_MatchOr(asdl_pattern_seq * patterns, int lineno, int
+                          col_offset, int end_lineno, int end_col_offset,
+                          PyArena *arena);
 type_ignore_ty _PyAST_TypeIgnore(int lineno, string tag, PyArena *arena);
 
 

--- a/Include/internal/pycore_ast_state.h
+++ b/Include/internal/pycore_ast_state.h
@@ -91,8 +91,15 @@ struct ast_state {
     PyObject *Lt_type;
     PyObject *MatMult_singleton;
     PyObject *MatMult_type;
+    PyObject *MatchAlways_type;
     PyObject *MatchAs_type;
+    PyObject *MatchClass_type;
+    PyObject *MatchConstant_type;
+    PyObject *MatchMapping_type;
     PyObject *MatchOr_type;
+    PyObject *MatchRestOfSequence_type;
+    PyObject *MatchSequence_type;
+    PyObject *MatchValue_type;
     PyObject *Match_type;
     PyObject *Mod_singleton;
     PyObject *Mod_type;
@@ -159,6 +166,7 @@ struct ast_state {
     PyObject *boolop_type;
     PyObject *cases;
     PyObject *cause;
+    PyObject *cls;
     PyObject *cmpop_type;
     PyObject *col_offset;
     PyObject *comparators;
@@ -176,6 +184,8 @@ struct ast_state {
     PyObject *excepthandler_type;
     PyObject *expr_context_type;
     PyObject *expr_type;
+    PyObject *extra_attrs;
+    PyObject *extra_patterns;
     PyObject *finalbody;
     PyObject *format_spec;
     PyObject *func;
@@ -212,6 +222,7 @@ struct ast_state {
     PyObject *optional_vars;
     PyObject *orelse;
     PyObject *pattern;
+    PyObject *pattern_type;
     PyObject *patterns;
     PyObject *posonlyargs;
     PyObject *returns;

--- a/Parser/Python.asdl
+++ b/Parser/Python.asdl
@@ -89,10 +89,6 @@ module Python
          -- can appear only in Subscript
          | Slice(expr? lower, expr? upper, expr? step)
 
-         -- only used in patterns
-         | MatchAs(expr pattern, identifier name)
-         | MatchOr(expr* patterns)
-
           -- col_offset is the byte offset in the utf8 string the parser uses
           attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
 
@@ -128,7 +124,21 @@ module Python
 
     withitem = (expr context_expr, expr? optional_vars)
 
-    match_case = (expr pattern, expr? guard, stmt* body)
+    match_case = (pattern pattern, expr? guard, stmt* body)
+
+    pattern = MatchAlways
+         | MatchValue(expr value)
+         | MatchConstant(constant value)
+         | MatchSequence(pattern* patterns)
+         | MatchMapping(expr* keys, pattern* patterns)
+         | MatchClass(expr cls, pattern* patterns, identifier* extra_attrs, pattern* extra_patterns)
+
+         | MatchRestOfSequence(identifier? target)
+         -- A NULL entry in the MatchMapping key list handles capturing extra mapping keys
+
+         | MatchAs(pattern? pattern, identifier target)
+         | MatchOr(pattern* patterns)
+          attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
 
     type_ignore = TypeIgnore(int lineno, string tag)
 }

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -119,353 +119,356 @@ static char *soft_keywords[] = {
 #define or_pattern_type 1045
 #define closed_pattern_type 1046
 #define literal_pattern_type 1047
-#define signed_number_type 1048
-#define capture_pattern_type 1049
-#define wildcard_pattern_type 1050
-#define value_pattern_type 1051
-#define attr_type 1052  // Left-recursive
-#define name_or_attr_type 1053  // Left-recursive
-#define group_pattern_type 1054
-#define sequence_pattern_type 1055
-#define open_sequence_pattern_type 1056
-#define maybe_sequence_pattern_type 1057
-#define maybe_star_pattern_type 1058
-#define star_pattern_type 1059
-#define mapping_pattern_type 1060
-#define items_pattern_type 1061
-#define key_value_pattern_type 1062
-#define double_star_pattern_type 1063
-#define class_pattern_type 1064
-#define positional_patterns_type 1065
-#define keyword_patterns_type 1066
-#define keyword_pattern_type 1067
-#define return_stmt_type 1068
-#define raise_stmt_type 1069
-#define function_def_type 1070
-#define function_def_raw_type 1071
-#define func_type_comment_type 1072
-#define params_type 1073
-#define parameters_type 1074
-#define slash_no_default_type 1075
-#define slash_with_default_type 1076
-#define star_etc_type 1077
-#define kwds_type 1078
-#define param_no_default_type 1079
-#define param_with_default_type 1080
-#define param_maybe_default_type 1081
-#define param_type 1082
-#define annotation_type 1083
-#define default_type 1084
-#define decorators_type 1085
-#define class_def_type 1086
-#define class_def_raw_type 1087
-#define block_type 1088
-#define star_expressions_type 1089
-#define star_expression_type 1090
-#define star_named_expressions_type 1091
-#define star_named_expression_type 1092
-#define named_expression_type 1093
-#define direct_named_expression_type 1094
-#define annotated_rhs_type 1095
-#define expressions_type 1096
-#define expression_type 1097
-#define lambdef_type 1098
-#define lambda_params_type 1099
-#define lambda_parameters_type 1100
-#define lambda_slash_no_default_type 1101
-#define lambda_slash_with_default_type 1102
-#define lambda_star_etc_type 1103
-#define lambda_kwds_type 1104
-#define lambda_param_no_default_type 1105
-#define lambda_param_with_default_type 1106
-#define lambda_param_maybe_default_type 1107
-#define lambda_param_type 1108
-#define disjunction_type 1109
-#define conjunction_type 1110
-#define inversion_type 1111
-#define comparison_type 1112
-#define compare_op_bitwise_or_pair_type 1113
-#define eq_bitwise_or_type 1114
-#define noteq_bitwise_or_type 1115
-#define lte_bitwise_or_type 1116
-#define lt_bitwise_or_type 1117
-#define gte_bitwise_or_type 1118
-#define gt_bitwise_or_type 1119
-#define notin_bitwise_or_type 1120
-#define in_bitwise_or_type 1121
-#define isnot_bitwise_or_type 1122
-#define is_bitwise_or_type 1123
-#define bitwise_or_type 1124  // Left-recursive
-#define bitwise_xor_type 1125  // Left-recursive
-#define bitwise_and_type 1126  // Left-recursive
-#define shift_expr_type 1127  // Left-recursive
-#define sum_type 1128  // Left-recursive
-#define term_type 1129  // Left-recursive
-#define factor_type 1130
-#define power_type 1131
-#define await_primary_type 1132
-#define primary_type 1133  // Left-recursive
-#define slices_type 1134
-#define slice_type 1135
-#define atom_type 1136
-#define strings_type 1137
-#define list_type 1138
-#define listcomp_type 1139
-#define tuple_type 1140
-#define group_type 1141
-#define genexp_type 1142
-#define set_type 1143
-#define setcomp_type 1144
-#define dict_type 1145
-#define dictcomp_type 1146
-#define double_starred_kvpairs_type 1147
-#define double_starred_kvpair_type 1148
-#define kvpair_type 1149
-#define for_if_clauses_type 1150
-#define for_if_clause_type 1151
-#define yield_expr_type 1152
-#define arguments_type 1153
-#define args_type 1154
-#define kwargs_type 1155
-#define starred_expression_type 1156
-#define kwarg_or_starred_type 1157
-#define kwarg_or_double_starred_type 1158
-#define star_targets_type 1159
-#define star_targets_list_seq_type 1160
-#define star_targets_tuple_seq_type 1161
-#define star_target_type 1162
-#define target_with_star_atom_type 1163
-#define star_atom_type 1164
-#define single_target_type 1165
-#define single_subscript_attribute_target_type 1166
-#define del_targets_type 1167
-#define del_target_type 1168
-#define del_t_atom_type 1169
-#define targets_type 1170
-#define target_type 1171
-#define t_primary_type 1172  // Left-recursive
-#define t_lookahead_type 1173
-#define t_atom_type 1174
-#define invalid_arguments_type 1175
-#define invalid_kwarg_type 1176
-#define invalid_expression_type 1177
-#define invalid_named_expression_type 1178
-#define invalid_assignment_type 1179
-#define invalid_ann_assign_target_type 1180
-#define invalid_del_stmt_type 1181
-#define invalid_block_type 1182
-#define invalid_primary_type 1183  // Left-recursive
-#define invalid_comprehension_type 1184
-#define invalid_dict_comprehension_type 1185
-#define invalid_parameters_type 1186
-#define invalid_parameters_helper_type 1187
-#define invalid_lambda_parameters_type 1188
-#define invalid_lambda_parameters_helper_type 1189
-#define invalid_star_etc_type 1190
-#define invalid_lambda_star_etc_type 1191
-#define invalid_double_type_comments_type 1192
-#define invalid_with_item_type 1193
-#define invalid_for_target_type 1194
-#define invalid_group_type 1195
-#define invalid_import_from_targets_type 1196
-#define invalid_with_stmt_type 1197
-#define invalid_except_block_type 1198
-#define invalid_match_stmt_type 1199
-#define invalid_case_block_type 1200
-#define invalid_if_stmt_type 1201
-#define invalid_elif_stmt_type 1202
-#define invalid_while_stmt_type 1203
-#define invalid_double_starred_kvpairs_type 1204
-#define invalid_kvpair_type 1205
-#define _loop0_1_type 1206
-#define _loop0_2_type 1207
-#define _loop0_4_type 1208
-#define _gather_3_type 1209
-#define _loop0_6_type 1210
-#define _gather_5_type 1211
-#define _loop0_8_type 1212
-#define _gather_7_type 1213
-#define _loop0_10_type 1214
-#define _gather_9_type 1215
-#define _loop1_11_type 1216
-#define _loop0_13_type 1217
-#define _gather_12_type 1218
-#define _tmp_14_type 1219
-#define _tmp_15_type 1220
-#define _tmp_16_type 1221
-#define _tmp_17_type 1222
-#define _tmp_18_type 1223
-#define _tmp_19_type 1224
-#define _tmp_20_type 1225
-#define _tmp_21_type 1226
-#define _loop1_22_type 1227
-#define _tmp_23_type 1228
-#define _tmp_24_type 1229
-#define _loop0_26_type 1230
-#define _gather_25_type 1231
-#define _loop0_28_type 1232
-#define _gather_27_type 1233
-#define _tmp_29_type 1234
-#define _tmp_30_type 1235
-#define _loop0_31_type 1236
-#define _loop1_32_type 1237
-#define _loop0_34_type 1238
-#define _gather_33_type 1239
-#define _tmp_35_type 1240
-#define _loop0_37_type 1241
-#define _gather_36_type 1242
-#define _tmp_38_type 1243
-#define _loop0_40_type 1244
-#define _gather_39_type 1245
-#define _loop0_42_type 1246
-#define _gather_41_type 1247
-#define _loop0_44_type 1248
-#define _gather_43_type 1249
-#define _loop0_46_type 1250
-#define _gather_45_type 1251
-#define _tmp_47_type 1252
-#define _loop1_48_type 1253
-#define _tmp_49_type 1254
-#define _loop1_50_type 1255
-#define _loop0_52_type 1256
-#define _gather_51_type 1257
-#define _tmp_53_type 1258
-#define _tmp_54_type 1259
-#define _tmp_55_type 1260
-#define _loop0_57_type 1261
-#define _gather_56_type 1262
-#define _tmp_58_type 1263
-#define _loop0_60_type 1264
-#define _gather_59_type 1265
-#define _tmp_61_type 1266
-#define _loop0_63_type 1267
-#define _gather_62_type 1268
-#define _loop0_65_type 1269
-#define _gather_64_type 1270
-#define _tmp_66_type 1271
-#define _tmp_67_type 1272
-#define _tmp_68_type 1273
-#define _tmp_69_type 1274
-#define _loop0_70_type 1275
-#define _loop0_71_type 1276
-#define _loop0_72_type 1277
-#define _loop1_73_type 1278
-#define _loop0_74_type 1279
-#define _loop1_75_type 1280
-#define _loop1_76_type 1281
-#define _loop1_77_type 1282
-#define _loop0_78_type 1283
-#define _loop1_79_type 1284
-#define _loop0_80_type 1285
-#define _loop1_81_type 1286
-#define _loop0_82_type 1287
-#define _loop1_83_type 1288
-#define _loop1_84_type 1289
-#define _tmp_85_type 1290
-#define _loop1_86_type 1291
-#define _loop0_88_type 1292
-#define _gather_87_type 1293
-#define _loop1_89_type 1294
-#define _loop0_90_type 1295
-#define _loop0_91_type 1296
-#define _loop0_92_type 1297
-#define _loop1_93_type 1298
-#define _loop0_94_type 1299
-#define _loop1_95_type 1300
-#define _loop1_96_type 1301
-#define _loop1_97_type 1302
-#define _loop0_98_type 1303
-#define _loop1_99_type 1304
-#define _loop0_100_type 1305
-#define _loop1_101_type 1306
-#define _loop0_102_type 1307
-#define _loop1_103_type 1308
-#define _loop1_104_type 1309
-#define _loop1_105_type 1310
-#define _loop1_106_type 1311
-#define _tmp_107_type 1312
-#define _loop0_109_type 1313
-#define _gather_108_type 1314
-#define _tmp_110_type 1315
-#define _tmp_111_type 1316
-#define _tmp_112_type 1317
-#define _tmp_113_type 1318
-#define _loop1_114_type 1319
-#define _tmp_115_type 1320
-#define _tmp_116_type 1321
-#define _loop0_118_type 1322
-#define _gather_117_type 1323
-#define _loop1_119_type 1324
-#define _loop0_120_type 1325
-#define _loop0_121_type 1326
-#define _loop0_123_type 1327
-#define _gather_122_type 1328
-#define _tmp_124_type 1329
-#define _loop0_126_type 1330
-#define _gather_125_type 1331
-#define _loop0_128_type 1332
-#define _gather_127_type 1333
-#define _loop0_130_type 1334
-#define _gather_129_type 1335
-#define _loop0_132_type 1336
-#define _gather_131_type 1337
-#define _loop0_133_type 1338
-#define _loop0_135_type 1339
-#define _gather_134_type 1340
-#define _loop1_136_type 1341
-#define _tmp_137_type 1342
-#define _loop0_139_type 1343
-#define _gather_138_type 1344
-#define _loop0_141_type 1345
-#define _gather_140_type 1346
-#define _tmp_142_type 1347
-#define _tmp_143_type 1348
-#define _tmp_144_type 1349
-#define _tmp_145_type 1350
-#define _tmp_146_type 1351
-#define _loop0_147_type 1352
-#define _loop0_148_type 1353
-#define _loop0_149_type 1354
-#define _tmp_150_type 1355
-#define _tmp_151_type 1356
-#define _tmp_152_type 1357
-#define _loop0_153_type 1358
-#define _loop1_154_type 1359
-#define _loop0_155_type 1360
-#define _loop1_156_type 1361
-#define _tmp_157_type 1362
-#define _tmp_158_type 1363
-#define _tmp_159_type 1364
-#define _loop0_161_type 1365
-#define _gather_160_type 1366
-#define _loop0_163_type 1367
-#define _gather_162_type 1368
-#define _tmp_164_type 1369
-#define _tmp_165_type 1370
-#define _loop0_167_type 1371
-#define _gather_166_type 1372
-#define _tmp_168_type 1373
-#define _tmp_169_type 1374
-#define _tmp_170_type 1375
-#define _tmp_171_type 1376
-#define _tmp_172_type 1377
-#define _tmp_173_type 1378
-#define _tmp_174_type 1379
-#define _tmp_175_type 1380
-#define _tmp_176_type 1381
-#define _tmp_177_type 1382
-#define _tmp_178_type 1383
-#define _tmp_179_type 1384
-#define _tmp_180_type 1385
-#define _tmp_181_type 1386
-#define _tmp_182_type 1387
-#define _tmp_183_type 1388
-#define _tmp_184_type 1389
-#define _tmp_185_type 1390
-#define _tmp_186_type 1391
-#define _tmp_187_type 1392
-#define _tmp_188_type 1393
-#define _tmp_189_type 1394
+#define literal_expr_type 1048
+#define complex_number_type 1049
+#define signed_number_type 1050
+#define capture_pattern_type 1051
+#define pattern_capture_target_type 1052
+#define wildcard_pattern_type 1053
+#define value_pattern_type 1054
+#define attr_type 1055  // Left-recursive
+#define name_or_attr_type 1056  // Left-recursive
+#define group_pattern_type 1057
+#define sequence_pattern_type 1058
+#define open_sequence_pattern_type 1059
+#define maybe_sequence_pattern_type 1060
+#define maybe_star_pattern_type 1061
+#define star_pattern_type 1062
+#define mapping_pattern_type 1063
+#define items_pattern_type 1064
+#define key_value_pattern_type 1065
+#define double_star_pattern_type 1066
+#define class_pattern_type 1067
+#define positional_patterns_type 1068
+#define keyword_patterns_type 1069
+#define keyword_pattern_type 1070
+#define return_stmt_type 1071
+#define raise_stmt_type 1072
+#define function_def_type 1073
+#define function_def_raw_type 1074
+#define func_type_comment_type 1075
+#define params_type 1076
+#define parameters_type 1077
+#define slash_no_default_type 1078
+#define slash_with_default_type 1079
+#define star_etc_type 1080
+#define kwds_type 1081
+#define param_no_default_type 1082
+#define param_with_default_type 1083
+#define param_maybe_default_type 1084
+#define param_type 1085
+#define annotation_type 1086
+#define default_type 1087
+#define decorators_type 1088
+#define class_def_type 1089
+#define class_def_raw_type 1090
+#define block_type 1091
+#define star_expressions_type 1092
+#define star_expression_type 1093
+#define star_named_expressions_type 1094
+#define star_named_expression_type 1095
+#define named_expression_type 1096
+#define direct_named_expression_type 1097
+#define annotated_rhs_type 1098
+#define expressions_type 1099
+#define expression_type 1100
+#define lambdef_type 1101
+#define lambda_params_type 1102
+#define lambda_parameters_type 1103
+#define lambda_slash_no_default_type 1104
+#define lambda_slash_with_default_type 1105
+#define lambda_star_etc_type 1106
+#define lambda_kwds_type 1107
+#define lambda_param_no_default_type 1108
+#define lambda_param_with_default_type 1109
+#define lambda_param_maybe_default_type 1110
+#define lambda_param_type 1111
+#define disjunction_type 1112
+#define conjunction_type 1113
+#define inversion_type 1114
+#define comparison_type 1115
+#define compare_op_bitwise_or_pair_type 1116
+#define eq_bitwise_or_type 1117
+#define noteq_bitwise_or_type 1118
+#define lte_bitwise_or_type 1119
+#define lt_bitwise_or_type 1120
+#define gte_bitwise_or_type 1121
+#define gt_bitwise_or_type 1122
+#define notin_bitwise_or_type 1123
+#define in_bitwise_or_type 1124
+#define isnot_bitwise_or_type 1125
+#define is_bitwise_or_type 1126
+#define bitwise_or_type 1127  // Left-recursive
+#define bitwise_xor_type 1128  // Left-recursive
+#define bitwise_and_type 1129  // Left-recursive
+#define shift_expr_type 1130  // Left-recursive
+#define sum_type 1131  // Left-recursive
+#define term_type 1132  // Left-recursive
+#define factor_type 1133
+#define power_type 1134
+#define await_primary_type 1135
+#define primary_type 1136  // Left-recursive
+#define slices_type 1137
+#define slice_type 1138
+#define atom_type 1139
+#define strings_type 1140
+#define list_type 1141
+#define listcomp_type 1142
+#define tuple_type 1143
+#define group_type 1144
+#define genexp_type 1145
+#define set_type 1146
+#define setcomp_type 1147
+#define dict_type 1148
+#define dictcomp_type 1149
+#define double_starred_kvpairs_type 1150
+#define double_starred_kvpair_type 1151
+#define kvpair_type 1152
+#define for_if_clauses_type 1153
+#define for_if_clause_type 1154
+#define yield_expr_type 1155
+#define arguments_type 1156
+#define args_type 1157
+#define kwargs_type 1158
+#define starred_expression_type 1159
+#define kwarg_or_starred_type 1160
+#define kwarg_or_double_starred_type 1161
+#define star_targets_type 1162
+#define star_targets_list_seq_type 1163
+#define star_targets_tuple_seq_type 1164
+#define star_target_type 1165
+#define target_with_star_atom_type 1166
+#define star_atom_type 1167
+#define single_target_type 1168
+#define single_subscript_attribute_target_type 1169
+#define del_targets_type 1170
+#define del_target_type 1171
+#define del_t_atom_type 1172
+#define targets_type 1173
+#define target_type 1174
+#define t_primary_type 1175  // Left-recursive
+#define t_lookahead_type 1176
+#define t_atom_type 1177
+#define invalid_arguments_type 1178
+#define invalid_kwarg_type 1179
+#define invalid_expression_type 1180
+#define invalid_named_expression_type 1181
+#define invalid_assignment_type 1182
+#define invalid_ann_assign_target_type 1183
+#define invalid_del_stmt_type 1184
+#define invalid_block_type 1185
+#define invalid_primary_type 1186  // Left-recursive
+#define invalid_comprehension_type 1187
+#define invalid_dict_comprehension_type 1188
+#define invalid_parameters_type 1189
+#define invalid_parameters_helper_type 1190
+#define invalid_lambda_parameters_type 1191
+#define invalid_lambda_parameters_helper_type 1192
+#define invalid_star_etc_type 1193
+#define invalid_lambda_star_etc_type 1194
+#define invalid_double_type_comments_type 1195
+#define invalid_with_item_type 1196
+#define invalid_for_target_type 1197
+#define invalid_group_type 1198
+#define invalid_import_from_targets_type 1199
+#define invalid_with_stmt_type 1200
+#define invalid_except_block_type 1201
+#define invalid_match_stmt_type 1202
+#define invalid_case_block_type 1203
+#define invalid_if_stmt_type 1204
+#define invalid_elif_stmt_type 1205
+#define invalid_while_stmt_type 1206
+#define invalid_double_starred_kvpairs_type 1207
+#define invalid_kvpair_type 1208
+#define _loop0_1_type 1209
+#define _loop0_2_type 1210
+#define _loop0_4_type 1211
+#define _gather_3_type 1212
+#define _loop0_6_type 1213
+#define _gather_5_type 1214
+#define _loop0_8_type 1215
+#define _gather_7_type 1216
+#define _loop0_10_type 1217
+#define _gather_9_type 1218
+#define _loop1_11_type 1219
+#define _loop0_13_type 1220
+#define _gather_12_type 1221
+#define _tmp_14_type 1222
+#define _tmp_15_type 1223
+#define _tmp_16_type 1224
+#define _tmp_17_type 1225
+#define _tmp_18_type 1226
+#define _tmp_19_type 1227
+#define _tmp_20_type 1228
+#define _tmp_21_type 1229
+#define _loop1_22_type 1230
+#define _tmp_23_type 1231
+#define _tmp_24_type 1232
+#define _loop0_26_type 1233
+#define _gather_25_type 1234
+#define _loop0_28_type 1235
+#define _gather_27_type 1236
+#define _tmp_29_type 1237
+#define _tmp_30_type 1238
+#define _loop0_31_type 1239
+#define _loop1_32_type 1240
+#define _loop0_34_type 1241
+#define _gather_33_type 1242
+#define _tmp_35_type 1243
+#define _loop0_37_type 1244
+#define _gather_36_type 1245
+#define _tmp_38_type 1246
+#define _loop0_40_type 1247
+#define _gather_39_type 1248
+#define _loop0_42_type 1249
+#define _gather_41_type 1250
+#define _loop0_44_type 1251
+#define _gather_43_type 1252
+#define _loop0_46_type 1253
+#define _gather_45_type 1254
+#define _tmp_47_type 1255
+#define _loop1_48_type 1256
+#define _tmp_49_type 1257
+#define _loop1_50_type 1258
+#define _loop0_52_type 1259
+#define _gather_51_type 1260
+#define _tmp_53_type 1261
+#define _tmp_54_type 1262
+#define _tmp_55_type 1263
+#define _tmp_56_type 1264
+#define _loop0_58_type 1265
+#define _gather_57_type 1266
+#define _loop0_60_type 1267
+#define _gather_59_type 1268
+#define _tmp_61_type 1269
+#define _loop0_63_type 1270
+#define _gather_62_type 1271
+#define _loop0_65_type 1272
+#define _gather_64_type 1273
+#define _tmp_66_type 1274
+#define _tmp_67_type 1275
+#define _tmp_68_type 1276
+#define _tmp_69_type 1277
+#define _loop0_70_type 1278
+#define _loop0_71_type 1279
+#define _loop0_72_type 1280
+#define _loop1_73_type 1281
+#define _loop0_74_type 1282
+#define _loop1_75_type 1283
+#define _loop1_76_type 1284
+#define _loop1_77_type 1285
+#define _loop0_78_type 1286
+#define _loop1_79_type 1287
+#define _loop0_80_type 1288
+#define _loop1_81_type 1289
+#define _loop0_82_type 1290
+#define _loop1_83_type 1291
+#define _loop1_84_type 1292
+#define _tmp_85_type 1293
+#define _loop1_86_type 1294
+#define _loop0_88_type 1295
+#define _gather_87_type 1296
+#define _loop1_89_type 1297
+#define _loop0_90_type 1298
+#define _loop0_91_type 1299
+#define _loop0_92_type 1300
+#define _loop1_93_type 1301
+#define _loop0_94_type 1302
+#define _loop1_95_type 1303
+#define _loop1_96_type 1304
+#define _loop1_97_type 1305
+#define _loop0_98_type 1306
+#define _loop1_99_type 1307
+#define _loop0_100_type 1308
+#define _loop1_101_type 1309
+#define _loop0_102_type 1310
+#define _loop1_103_type 1311
+#define _loop1_104_type 1312
+#define _loop1_105_type 1313
+#define _loop1_106_type 1314
+#define _tmp_107_type 1315
+#define _loop0_109_type 1316
+#define _gather_108_type 1317
+#define _tmp_110_type 1318
+#define _tmp_111_type 1319
+#define _tmp_112_type 1320
+#define _tmp_113_type 1321
+#define _loop1_114_type 1322
+#define _tmp_115_type 1323
+#define _tmp_116_type 1324
+#define _loop0_118_type 1325
+#define _gather_117_type 1326
+#define _loop1_119_type 1327
+#define _loop0_120_type 1328
+#define _loop0_121_type 1329
+#define _loop0_123_type 1330
+#define _gather_122_type 1331
+#define _tmp_124_type 1332
+#define _loop0_126_type 1333
+#define _gather_125_type 1334
+#define _loop0_128_type 1335
+#define _gather_127_type 1336
+#define _loop0_130_type 1337
+#define _gather_129_type 1338
+#define _loop0_132_type 1339
+#define _gather_131_type 1340
+#define _loop0_133_type 1341
+#define _loop0_135_type 1342
+#define _gather_134_type 1343
+#define _loop1_136_type 1344
+#define _tmp_137_type 1345
+#define _loop0_139_type 1346
+#define _gather_138_type 1347
+#define _loop0_141_type 1348
+#define _gather_140_type 1349
+#define _tmp_142_type 1350
+#define _tmp_143_type 1351
+#define _tmp_144_type 1352
+#define _tmp_145_type 1353
+#define _tmp_146_type 1354
+#define _loop0_147_type 1355
+#define _loop0_148_type 1356
+#define _loop0_149_type 1357
+#define _tmp_150_type 1358
+#define _tmp_151_type 1359
+#define _tmp_152_type 1360
+#define _loop0_153_type 1361
+#define _loop1_154_type 1362
+#define _loop0_155_type 1363
+#define _loop1_156_type 1364
+#define _tmp_157_type 1365
+#define _tmp_158_type 1366
+#define _tmp_159_type 1367
+#define _loop0_161_type 1368
+#define _gather_160_type 1369
+#define _loop0_163_type 1370
+#define _gather_162_type 1371
+#define _tmp_164_type 1372
+#define _tmp_165_type 1373
+#define _loop0_167_type 1374
+#define _gather_166_type 1375
+#define _tmp_168_type 1376
+#define _tmp_169_type 1377
+#define _tmp_170_type 1378
+#define _tmp_171_type 1379
+#define _tmp_172_type 1380
+#define _tmp_173_type 1381
+#define _tmp_174_type 1382
+#define _tmp_175_type 1383
+#define _tmp_176_type 1384
+#define _tmp_177_type 1385
+#define _tmp_178_type 1386
+#define _tmp_179_type 1387
+#define _tmp_180_type 1388
+#define _tmp_181_type 1389
+#define _tmp_182_type 1390
+#define _tmp_183_type 1391
+#define _tmp_184_type 1392
+#define _tmp_185_type 1393
+#define _tmp_186_type 1394
+#define _tmp_187_type 1395
+#define _tmp_188_type 1396
+#define _tmp_189_type 1397
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -509,32 +512,35 @@ static stmt_ty match_stmt_rule(Parser *p);
 static expr_ty subject_expr_rule(Parser *p);
 static match_case_ty case_block_rule(Parser *p);
 static expr_ty guard_rule(Parser *p);
-static expr_ty patterns_rule(Parser *p);
-static expr_ty pattern_rule(Parser *p);
-static expr_ty as_pattern_rule(Parser *p);
-static expr_ty or_pattern_rule(Parser *p);
-static expr_ty closed_pattern_rule(Parser *p);
-static expr_ty literal_pattern_rule(Parser *p);
+static pattern_ty patterns_rule(Parser *p);
+static pattern_ty pattern_rule(Parser *p);
+static pattern_ty as_pattern_rule(Parser *p);
+static pattern_ty or_pattern_rule(Parser *p);
+static pattern_ty closed_pattern_rule(Parser *p);
+static pattern_ty literal_pattern_rule(Parser *p);
+static expr_ty literal_expr_rule(Parser *p);
+static expr_ty complex_number_rule(Parser *p);
 static expr_ty signed_number_rule(Parser *p);
-static expr_ty capture_pattern_rule(Parser *p);
-static expr_ty wildcard_pattern_rule(Parser *p);
-static expr_ty value_pattern_rule(Parser *p);
+static pattern_ty capture_pattern_rule(Parser *p);
+static expr_ty pattern_capture_target_rule(Parser *p);
+static pattern_ty wildcard_pattern_rule(Parser *p);
+static pattern_ty value_pattern_rule(Parser *p);
 static expr_ty attr_rule(Parser *p);
 static expr_ty name_or_attr_rule(Parser *p);
-static expr_ty group_pattern_rule(Parser *p);
-static expr_ty sequence_pattern_rule(Parser *p);
+static pattern_ty group_pattern_rule(Parser *p);
+static pattern_ty sequence_pattern_rule(Parser *p);
 static asdl_seq* open_sequence_pattern_rule(Parser *p);
 static asdl_seq* maybe_sequence_pattern_rule(Parser *p);
-static expr_ty maybe_star_pattern_rule(Parser *p);
-static expr_ty star_pattern_rule(Parser *p);
-static expr_ty mapping_pattern_rule(Parser *p);
+static pattern_ty maybe_star_pattern_rule(Parser *p);
+static pattern_ty star_pattern_rule(Parser *p);
+static pattern_ty mapping_pattern_rule(Parser *p);
 static asdl_seq* items_pattern_rule(Parser *p);
-static KeyValuePair* key_value_pattern_rule(Parser *p);
-static KeyValuePair* double_star_pattern_rule(Parser *p);
-static expr_ty class_pattern_rule(Parser *p);
-static asdl_expr_seq* positional_patterns_rule(Parser *p);
-static asdl_keyword_seq* keyword_patterns_rule(Parser *p);
-static keyword_ty keyword_pattern_rule(Parser *p);
+static KeyPatternPair* key_value_pattern_rule(Parser *p);
+static KeyPatternPair* double_star_pattern_rule(Parser *p);
+static pattern_ty class_pattern_rule(Parser *p);
+static asdl_pattern_seq* positional_patterns_rule(Parser *p);
+static asdl_seq* keyword_patterns_rule(Parser *p);
+static pattern_ty keyword_pattern_rule(Parser *p);
 static stmt_ty return_stmt_rule(Parser *p);
 static stmt_ty raise_stmt_rule(Parser *p);
 static stmt_ty function_def_rule(Parser *p);
@@ -728,9 +734,9 @@ static asdl_seq *_gather_51_rule(Parser *p);
 static void *_tmp_53_rule(Parser *p);
 static void *_tmp_54_rule(Parser *p);
 static void *_tmp_55_rule(Parser *p);
-static asdl_seq *_loop0_57_rule(Parser *p);
-static asdl_seq *_gather_56_rule(Parser *p);
-static void *_tmp_58_rule(Parser *p);
+static void *_tmp_56_rule(Parser *p);
+static asdl_seq *_loop0_58_rule(Parser *p);
+static asdl_seq *_gather_57_rule(Parser *p);
 static asdl_seq *_loop0_60_rule(Parser *p);
 static asdl_seq *_gather_59_rule(Parser *p);
 static void *_tmp_61_rule(Parser *p);
@@ -5201,7 +5207,7 @@ case_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* body;
         void *guard;
-        expr_ty pattern;
+        pattern_ty pattern;
         if (
             (_keyword = _PyPegen_expect_soft_keyword(p, "case"))  // soft_keyword='"case"'
             &&
@@ -5297,7 +5303,7 @@ guard_rule(Parser *p)
 }
 
 // patterns: open_sequence_pattern | pattern
-static expr_ty
+static pattern_ty
 patterns_rule(Parser *p)
 {
     D(p->level++);
@@ -5305,7 +5311,7 @@ patterns_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -5322,9 +5328,9 @@ patterns_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> patterns[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "open_sequence_pattern"));
-        asdl_expr_seq* values;
+        asdl_pattern_seq* patterns;
         if (
-            (values = (asdl_expr_seq*)open_sequence_pattern_rule(p))  // open_sequence_pattern
+            (patterns = (asdl_pattern_seq*)open_sequence_pattern_rule(p))  // open_sequence_pattern
         )
         {
             D(fprintf(stderr, "%*c+ patterns[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "open_sequence_pattern"));
@@ -5337,7 +5343,7 @@ patterns_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Tuple ( values , Load , EXTRA );
+            _res = _PyAST_MatchSequence ( patterns , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5355,7 +5361,7 @@ patterns_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> patterns[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "pattern"));
-        expr_ty pattern_var;
+        pattern_ty pattern_var;
         if (
             (pattern_var = pattern_rule(p))  // pattern
         )
@@ -5375,7 +5381,7 @@ patterns_rule(Parser *p)
 }
 
 // pattern: as_pattern | or_pattern
-static expr_ty
+static pattern_ty
 pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -5383,7 +5389,7 @@ pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     { // as_pattern
         if (p->error_indicator) {
@@ -5391,7 +5397,7 @@ pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "as_pattern"));
-        expr_ty as_pattern_var;
+        pattern_ty as_pattern_var;
         if (
             (as_pattern_var = as_pattern_rule(p))  // as_pattern
         )
@@ -5410,7 +5416,7 @@ pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "or_pattern"));
-        expr_ty or_pattern_var;
+        pattern_ty or_pattern_var;
         if (
             (or_pattern_var = or_pattern_rule(p))  // or_pattern
         )
@@ -5429,8 +5435,8 @@ pattern_rule(Parser *p)
     return _res;
 }
 
-// as_pattern: or_pattern 'as' capture_pattern
-static expr_ty
+// as_pattern: or_pattern 'as' pattern_capture_target
+static pattern_ty
 as_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -5438,7 +5444,7 @@ as_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -5449,24 +5455,24 @@ as_pattern_rule(Parser *p)
     UNUSED(_start_lineno); // Only used by EXTRA macro
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
-    { // or_pattern 'as' capture_pattern
+    { // or_pattern 'as' pattern_capture_target
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> as_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "or_pattern 'as' capture_pattern"));
+        D(fprintf(stderr, "%*c> as_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "or_pattern 'as' pattern_capture_target"));
         Token * _keyword;
-        expr_ty pattern;
+        pattern_ty pattern;
         expr_ty target;
         if (
             (pattern = or_pattern_rule(p))  // or_pattern
             &&
             (_keyword = _PyPegen_expect_token(p, 520))  // token='as'
             &&
-            (target = capture_pattern_rule(p))  // capture_pattern
+            (target = pattern_capture_target_rule(p))  // pattern_capture_target
         )
         {
-            D(fprintf(stderr, "%*c+ as_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "or_pattern 'as' capture_pattern"));
+            D(fprintf(stderr, "%*c+ as_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "or_pattern 'as' pattern_capture_target"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 D(p->level--);
@@ -5486,7 +5492,7 @@ as_pattern_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s as_pattern[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "or_pattern 'as' capture_pattern"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "or_pattern 'as' pattern_capture_target"));
     }
     _res = NULL;
   done:
@@ -5495,7 +5501,7 @@ as_pattern_rule(Parser *p)
 }
 
 // or_pattern: '|'.closed_pattern+
-static expr_ty
+static pattern_ty
 or_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -5503,7 +5509,7 @@ or_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -5520,9 +5526,9 @@ or_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> or_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'|'.closed_pattern+"));
-        asdl_expr_seq* patterns;
+        asdl_pattern_seq* patterns;
         if (
-            (patterns = (asdl_expr_seq*)_gather_51_rule(p))  // '|'.closed_pattern+
+            (patterns = (asdl_pattern_seq*)_gather_51_rule(p))  // '|'.closed_pattern+
         )
         {
             D(fprintf(stderr, "%*c+ or_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'|'.closed_pattern+"));
@@ -5562,7 +5568,7 @@ or_pattern_rule(Parser *p)
 //     | sequence_pattern
 //     | mapping_pattern
 //     | class_pattern
-static expr_ty
+static pattern_ty
 closed_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -5570,7 +5576,7 @@ closed_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     { // literal_pattern
         if (p->error_indicator) {
@@ -5578,7 +5584,7 @@ closed_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "literal_pattern"));
-        expr_ty literal_pattern_var;
+        pattern_ty literal_pattern_var;
         if (
             (literal_pattern_var = literal_pattern_rule(p))  // literal_pattern
         )
@@ -5597,7 +5603,7 @@ closed_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "capture_pattern"));
-        expr_ty capture_pattern_var;
+        pattern_ty capture_pattern_var;
         if (
             (capture_pattern_var = capture_pattern_rule(p))  // capture_pattern
         )
@@ -5616,7 +5622,7 @@ closed_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "wildcard_pattern"));
-        expr_ty wildcard_pattern_var;
+        pattern_ty wildcard_pattern_var;
         if (
             (wildcard_pattern_var = wildcard_pattern_rule(p))  // wildcard_pattern
         )
@@ -5635,7 +5641,7 @@ closed_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "value_pattern"));
-        expr_ty value_pattern_var;
+        pattern_ty value_pattern_var;
         if (
             (value_pattern_var = value_pattern_rule(p))  // value_pattern
         )
@@ -5654,7 +5660,7 @@ closed_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "group_pattern"));
-        expr_ty group_pattern_var;
+        pattern_ty group_pattern_var;
         if (
             (group_pattern_var = group_pattern_rule(p))  // group_pattern
         )
@@ -5673,7 +5679,7 @@ closed_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "sequence_pattern"));
-        expr_ty sequence_pattern_var;
+        pattern_ty sequence_pattern_var;
         if (
             (sequence_pattern_var = sequence_pattern_rule(p))  // sequence_pattern
         )
@@ -5692,7 +5698,7 @@ closed_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "mapping_pattern"));
-        expr_ty mapping_pattern_var;
+        pattern_ty mapping_pattern_var;
         if (
             (mapping_pattern_var = mapping_pattern_rule(p))  // mapping_pattern
         )
@@ -5711,7 +5717,7 @@ closed_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> closed_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "class_pattern"));
-        expr_ty class_pattern_var;
+        pattern_ty class_pattern_var;
         if (
             (class_pattern_var = class_pattern_rule(p))  // class_pattern
         )
@@ -5732,13 +5738,12 @@ closed_pattern_rule(Parser *p)
 
 // literal_pattern:
 //     | signed_number !('+' | '-')
-//     | signed_number '+' NUMBER
-//     | signed_number '-' NUMBER
+//     | complex_number
 //     | strings
 //     | 'None'
 //     | 'True'
 //     | 'False'
-static expr_ty
+static pattern_ty
 literal_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -5746,7 +5751,7 @@ literal_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -5763,39 +5768,47 @@ literal_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_number !('+' | '-')"));
-        expr_ty signed_number_var;
+        expr_ty value;
         if (
-            (signed_number_var = signed_number_rule(p))  // signed_number
+            (value = signed_number_rule(p))  // signed_number
             &&
             _PyPegen_lookahead(0, _tmp_53_rule, p)
         )
         {
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_number !('+' | '-')"));
-            _res = signed_number_var;
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_MatchValue ( value , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s literal_pattern[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "signed_number !('+' | '-')"));
     }
-    { // signed_number '+' NUMBER
+    { // complex_number
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_number '+' NUMBER"));
-        Token * _literal;
-        expr_ty imag;
-        expr_ty real;
+        D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "complex_number"));
+        expr_ty value;
         if (
-            (real = signed_number_rule(p))  // signed_number
-            &&
-            (_literal = _PyPegen_expect_token(p, 14))  // token='+'
-            &&
-            (imag = _PyPegen_number_token(p))  // NUMBER
+            (value = complex_number_rule(p))  // complex_number
         )
         {
-            D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_number '+' NUMBER"));
+            D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "complex_number"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 D(p->level--);
@@ -5805,7 +5818,7 @@ literal_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_BinOp ( real , Add , imag , EXTRA );
+            _res = _PyAST_MatchValue ( value , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5815,46 +5828,7 @@ literal_pattern_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s literal_pattern[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "signed_number '+' NUMBER"));
-    }
-    { // signed_number '-' NUMBER
-        if (p->error_indicator) {
-            D(p->level--);
-            return NULL;
-        }
-        D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_number '-' NUMBER"));
-        Token * _literal;
-        expr_ty imag;
-        expr_ty real;
-        if (
-            (real = signed_number_rule(p))  // signed_number
-            &&
-            (_literal = _PyPegen_expect_token(p, 15))  // token='-'
-            &&
-            (imag = _PyPegen_number_token(p))  // NUMBER
-        )
-        {
-            D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_number '-' NUMBER"));
-            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
-            if (_token == NULL) {
-                D(p->level--);
-                return NULL;
-            }
-            int _end_lineno = _token->end_lineno;
-            UNUSED(_end_lineno); // Only used by EXTRA macro
-            int _end_col_offset = _token->end_col_offset;
-            UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_BinOp ( real , Sub , imag , EXTRA );
-            if (_res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                D(p->level--);
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = _mark;
-        D(fprintf(stderr, "%*c%s literal_pattern[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "signed_number '-' NUMBER"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "complex_number"));
     }
     { // strings
         if (p->error_indicator) {
@@ -5862,13 +5836,27 @@ literal_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "strings"));
-        expr_ty strings_var;
+        expr_ty value;
         if (
-            (strings_var = strings_rule(p))  // strings
+            (value = strings_rule(p))  // strings
         )
         {
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "strings"));
-            _res = strings_var;
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_MatchValue ( value , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
             goto done;
         }
         p->mark = _mark;
@@ -5896,7 +5884,7 @@ literal_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Constant ( Py_None , NULL , EXTRA );
+            _res = _PyAST_MatchConstant ( Py_None , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5929,7 +5917,7 @@ literal_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Constant ( Py_True , NULL , EXTRA );
+            _res = _PyAST_MatchConstant ( Py_True , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5962,7 +5950,7 @@ literal_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Constant ( Py_False , NULL , EXTRA );
+            _res = _PyAST_MatchConstant ( Py_False , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5973,6 +5961,300 @@ literal_pattern_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s literal_pattern[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'False'"));
+    }
+    _res = NULL;
+  done:
+    D(p->level--);
+    return _res;
+}
+
+// literal_expr:
+//     | signed_number !('+' | '-')
+//     | complex_number
+//     | strings
+//     | 'None'
+//     | 'True'
+//     | 'False'
+static expr_ty
+literal_expr_rule(Parser *p)
+{
+    D(p->level++);
+    if (p->error_indicator) {
+        D(p->level--);
+        return NULL;
+    }
+    expr_ty _res = NULL;
+    int _mark = p->mark;
+    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
+        p->error_indicator = 1;
+        D(p->level--);
+        return NULL;
+    }
+    int _start_lineno = p->tokens[_mark]->lineno;
+    UNUSED(_start_lineno); // Only used by EXTRA macro
+    int _start_col_offset = p->tokens[_mark]->col_offset;
+    UNUSED(_start_col_offset); // Only used by EXTRA macro
+    { // signed_number !('+' | '-')
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_number !('+' | '-')"));
+        expr_ty signed_number_var;
+        if (
+            (signed_number_var = signed_number_rule(p))  // signed_number
+            &&
+            _PyPegen_lookahead(0, _tmp_54_rule, p)
+        )
+        {
+            D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_number !('+' | '-')"));
+            _res = signed_number_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s literal_expr[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "signed_number !('+' | '-')"));
+    }
+    { // complex_number
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "complex_number"));
+        expr_ty complex_number_var;
+        if (
+            (complex_number_var = complex_number_rule(p))  // complex_number
+        )
+        {
+            D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "complex_number"));
+            _res = complex_number_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s literal_expr[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "complex_number"));
+    }
+    { // strings
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "strings"));
+        expr_ty strings_var;
+        if (
+            (strings_var = strings_rule(p))  // strings
+        )
+        {
+            D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "strings"));
+            _res = strings_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s literal_expr[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "strings"));
+    }
+    { // 'None'
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
+        Token * _keyword;
+        if (
+            (_keyword = _PyPegen_expect_token(p, 523))  // token='None'
+        )
+        {
+            D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'None'"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_Constant ( Py_None , NULL , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s literal_expr[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'None'"));
+    }
+    { // 'True'
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
+        Token * _keyword;
+        if (
+            (_keyword = _PyPegen_expect_token(p, 524))  // token='True'
+        )
+        {
+            D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'True'"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_Constant ( Py_True , NULL , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s literal_expr[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'True'"));
+    }
+    { // 'False'
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
+        Token * _keyword;
+        if (
+            (_keyword = _PyPegen_expect_token(p, 525))  // token='False'
+        )
+        {
+            D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'False'"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_Constant ( Py_False , NULL , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s literal_expr[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'False'"));
+    }
+    _res = NULL;
+  done:
+    D(p->level--);
+    return _res;
+}
+
+// complex_number: signed_number '+' NUMBER | signed_number '-' NUMBER
+static expr_ty
+complex_number_rule(Parser *p)
+{
+    D(p->level++);
+    if (p->error_indicator) {
+        D(p->level--);
+        return NULL;
+    }
+    expr_ty _res = NULL;
+    int _mark = p->mark;
+    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
+        p->error_indicator = 1;
+        D(p->level--);
+        return NULL;
+    }
+    int _start_lineno = p->tokens[_mark]->lineno;
+    UNUSED(_start_lineno); // Only used by EXTRA macro
+    int _start_col_offset = p->tokens[_mark]->col_offset;
+    UNUSED(_start_col_offset); // Only used by EXTRA macro
+    { // signed_number '+' NUMBER
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> complex_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_number '+' NUMBER"));
+        Token * _literal;
+        expr_ty imag;
+        expr_ty real;
+        if (
+            (real = signed_number_rule(p))  // signed_number
+            &&
+            (_literal = _PyPegen_expect_token(p, 14))  // token='+'
+            &&
+            (imag = _PyPegen_number_token(p))  // NUMBER
+        )
+        {
+            D(fprintf(stderr, "%*c+ complex_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_number '+' NUMBER"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_BinOp ( real , Add , imag , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s complex_number[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "signed_number '+' NUMBER"));
+    }
+    { // signed_number '-' NUMBER
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> complex_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_number '-' NUMBER"));
+        Token * _literal;
+        expr_ty imag;
+        expr_ty real;
+        if (
+            (real = signed_number_rule(p))  // signed_number
+            &&
+            (_literal = _PyPegen_expect_token(p, 15))  // token='-'
+            &&
+            (imag = _PyPegen_number_token(p))  // NUMBER
+        )
+        {
+            D(fprintf(stderr, "%*c+ complex_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_number '-' NUMBER"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_BinOp ( real , Sub , imag , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s complex_number[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "signed_number '-' NUMBER"));
     }
     _res = NULL;
   done:
@@ -6061,9 +6343,68 @@ signed_number_rule(Parser *p)
     return _res;
 }
 
-// capture_pattern: !"_" NAME !('.' | '(' | '=')
-static expr_ty
+// capture_pattern: pattern_capture_target
+static pattern_ty
 capture_pattern_rule(Parser *p)
+{
+    D(p->level++);
+    if (p->error_indicator) {
+        D(p->level--);
+        return NULL;
+    }
+    pattern_ty _res = NULL;
+    int _mark = p->mark;
+    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
+        p->error_indicator = 1;
+        D(p->level--);
+        return NULL;
+    }
+    int _start_lineno = p->tokens[_mark]->lineno;
+    UNUSED(_start_lineno); // Only used by EXTRA macro
+    int _start_col_offset = p->tokens[_mark]->col_offset;
+    UNUSED(_start_col_offset); // Only used by EXTRA macro
+    { // pattern_capture_target
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> capture_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "pattern_capture_target"));
+        expr_ty target;
+        if (
+            (target = pattern_capture_target_rule(p))  // pattern_capture_target
+        )
+        {
+            D(fprintf(stderr, "%*c+ capture_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "pattern_capture_target"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_MatchAs ( NULL , target -> v . Name . id , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s capture_pattern[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "pattern_capture_target"));
+    }
+    _res = NULL;
+  done:
+    D(p->level--);
+    return _res;
+}
+
+// pattern_capture_target: !"_" NAME !('.' | '(' | '=')
+static expr_ty
+pattern_capture_target_rule(Parser *p)
 {
     D(p->level++);
     if (p->error_indicator) {
@@ -6077,17 +6418,17 @@ capture_pattern_rule(Parser *p)
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> capture_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "!\"_\" NAME !('.' | '(' | '=')"));
+        D(fprintf(stderr, "%*c> pattern_capture_target[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "!\"_\" NAME !('.' | '(' | '=')"));
         expr_ty name;
         if (
             _PyPegen_lookahead_with_string(0, _PyPegen_expect_soft_keyword, p, "_")
             &&
             (name = _PyPegen_name_token(p))  // NAME
             &&
-            _PyPegen_lookahead(0, _tmp_54_rule, p)
+            _PyPegen_lookahead(0, _tmp_55_rule, p)
         )
         {
-            D(fprintf(stderr, "%*c+ capture_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "!\"_\" NAME !('.' | '(' | '=')"));
+            D(fprintf(stderr, "%*c+ pattern_capture_target[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "!\"_\" NAME !('.' | '(' | '=')"));
             _res = _PyPegen_set_expr_context ( p , name , Store );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -6097,7 +6438,7 @@ capture_pattern_rule(Parser *p)
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s capture_pattern[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s pattern_capture_target[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "!\"_\" NAME !('.' | '(' | '=')"));
     }
     _res = NULL;
@@ -6107,7 +6448,7 @@ capture_pattern_rule(Parser *p)
 }
 
 // wildcard_pattern: "_"
-static expr_ty
+static pattern_ty
 wildcard_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -6115,7 +6456,7 @@ wildcard_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -6147,7 +6488,7 @@ wildcard_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Name ( CHECK ( PyObject * , _PyPegen_new_identifier ( p , "_" ) ) , Store , EXTRA );
+            _res = _PyAST_MatchAlways ( EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6166,7 +6507,7 @@ wildcard_pattern_rule(Parser *p)
 }
 
 // value_pattern: attr !('.' | '(' | '=')
-static expr_ty
+static pattern_ty
 value_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -6174,8 +6515,17 @@ value_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
+    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
+        p->error_indicator = 1;
+        D(p->level--);
+        return NULL;
+    }
+    int _start_lineno = p->tokens[_mark]->lineno;
+    UNUSED(_start_lineno); // Only used by EXTRA macro
+    int _start_col_offset = p->tokens[_mark]->col_offset;
+    UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // attr !('.' | '(' | '=')
         if (p->error_indicator) {
             D(p->level--);
@@ -6186,11 +6536,20 @@ value_pattern_rule(Parser *p)
         if (
             (attr = attr_rule(p))  // attr
             &&
-            _PyPegen_lookahead(0, _tmp_55_rule, p)
+            _PyPegen_lookahead(0, _tmp_56_rule, p)
         )
         {
             D(fprintf(stderr, "%*c+ value_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "attr !('.' | '(' | '=')"));
-            _res = attr;
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_MatchValue ( attr , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6362,7 +6721,7 @@ name_or_attr_rule(Parser *p)
 }
 
 // group_pattern: '(' pattern ')'
-static expr_ty
+static pattern_ty
 group_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -6370,7 +6729,7 @@ group_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     { // '(' pattern ')'
         if (p->error_indicator) {
@@ -6380,7 +6739,7 @@ group_pattern_rule(Parser *p)
         D(fprintf(stderr, "%*c> group_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' pattern ')'"));
         Token * _literal;
         Token * _literal_1;
-        expr_ty pattern;
+        pattern_ty pattern;
         if (
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -6409,7 +6768,7 @@ group_pattern_rule(Parser *p)
 }
 
 // sequence_pattern: '[' maybe_sequence_pattern? ']' | '(' open_sequence_pattern? ')'
-static expr_ty
+static pattern_ty
 sequence_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -6417,7 +6776,7 @@ sequence_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -6436,11 +6795,11 @@ sequence_pattern_rule(Parser *p)
         D(fprintf(stderr, "%*c> sequence_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'[' maybe_sequence_pattern? ']'"));
         Token * _literal;
         Token * _literal_1;
-        void *values;
+        void *patterns;
         if (
             (_literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (values = maybe_sequence_pattern_rule(p), 1)  // maybe_sequence_pattern?
+            (patterns = maybe_sequence_pattern_rule(p), 1)  // maybe_sequence_pattern?
             &&
             (_literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
         )
@@ -6455,7 +6814,7 @@ sequence_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_List ( values , Load , EXTRA );
+            _res = _PyAST_MatchSequence ( patterns , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6475,11 +6834,11 @@ sequence_pattern_rule(Parser *p)
         D(fprintf(stderr, "%*c> sequence_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' open_sequence_pattern? ')'"));
         Token * _literal;
         Token * _literal_1;
-        void *values;
+        void *patterns;
         if (
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (values = open_sequence_pattern_rule(p), 1)  // open_sequence_pattern?
+            (patterns = open_sequence_pattern_rule(p), 1)  // open_sequence_pattern?
             &&
             (_literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
@@ -6494,7 +6853,7 @@ sequence_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Tuple ( values , Load , EXTRA );
+            _res = _PyAST_MatchSequence ( patterns , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6530,18 +6889,18 @@ open_sequence_pattern_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> open_sequence_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "maybe_star_pattern ',' maybe_sequence_pattern?"));
         Token * _literal;
-        expr_ty value;
-        void *values;
+        pattern_ty pattern;
+        void *patterns;
         if (
-            (value = maybe_star_pattern_rule(p))  // maybe_star_pattern
+            (pattern = maybe_star_pattern_rule(p))  // maybe_star_pattern
             &&
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (values = maybe_sequence_pattern_rule(p), 1)  // maybe_sequence_pattern?
+            (patterns = maybe_sequence_pattern_rule(p), 1)  // maybe_sequence_pattern?
         )
         {
             D(fprintf(stderr, "%*c+ open_sequence_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "maybe_star_pattern ',' maybe_sequence_pattern?"));
-            _res = _PyPegen_seq_insert_in_front ( p , value , values );
+            _res = _PyPegen_seq_insert_in_front ( p , pattern , patterns );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6578,15 +6937,15 @@ maybe_sequence_pattern_rule(Parser *p)
         D(fprintf(stderr, "%*c> maybe_sequence_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.maybe_star_pattern+ ','?"));
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq * values;
+        asdl_seq * patterns;
         if (
-            (values = _gather_56_rule(p))  // ','.maybe_star_pattern+
+            (patterns = _gather_57_rule(p))  // ','.maybe_star_pattern+
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             D(fprintf(stderr, "%*c+ maybe_sequence_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.maybe_star_pattern+ ','?"));
-            _res = values;
+            _res = patterns;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6605,7 +6964,7 @@ maybe_sequence_pattern_rule(Parser *p)
 }
 
 // maybe_star_pattern: star_pattern | pattern
-static expr_ty
+static pattern_ty
 maybe_star_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -6613,7 +6972,7 @@ maybe_star_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     { // star_pattern
         if (p->error_indicator) {
@@ -6621,7 +6980,7 @@ maybe_star_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> maybe_star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_pattern"));
-        expr_ty star_pattern_var;
+        pattern_ty star_pattern_var;
         if (
             (star_pattern_var = star_pattern_rule(p))  // star_pattern
         )
@@ -6640,7 +6999,7 @@ maybe_star_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> maybe_star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "pattern"));
-        expr_ty pattern_var;
+        pattern_ty pattern_var;
         if (
             (pattern_var = pattern_rule(p))  // pattern
         )
@@ -6659,8 +7018,8 @@ maybe_star_pattern_rule(Parser *p)
     return _res;
 }
 
-// star_pattern: '*' (capture_pattern | wildcard_pattern)
-static expr_ty
+// star_pattern: '*' pattern_capture_target | '*' wildcard_pattern
+static pattern_ty
 star_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -6668,7 +7027,7 @@ star_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -6679,21 +7038,21 @@ star_pattern_rule(Parser *p)
     UNUSED(_start_lineno); // Only used by EXTRA macro
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
-    { // '*' (capture_pattern | wildcard_pattern)
+    { // '*' pattern_capture_target
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' (capture_pattern | wildcard_pattern)"));
+        D(fprintf(stderr, "%*c> star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' pattern_capture_target"));
         Token * _literal;
-        void *value;
+        expr_ty target;
         if (
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (value = _tmp_58_rule(p))  // capture_pattern | wildcard_pattern
+            (target = pattern_capture_target_rule(p))  // pattern_capture_target
         )
         {
-            D(fprintf(stderr, "%*c+ star_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' (capture_pattern | wildcard_pattern)"));
+            D(fprintf(stderr, "%*c+ star_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' pattern_capture_target"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 D(p->level--);
@@ -6703,7 +7062,7 @@ star_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Starred ( value , Store , EXTRA );
+            _res = _PyAST_MatchRestOfSequence ( target -> v . Name . id , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6713,7 +7072,43 @@ star_pattern_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s star_pattern[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'*' (capture_pattern | wildcard_pattern)"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'*' pattern_capture_target"));
+    }
+    { // '*' wildcard_pattern
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' wildcard_pattern"));
+        Token * _literal;
+        pattern_ty wildcard_pattern_var;
+        if (
+            (_literal = _PyPegen_expect_token(p, 16))  // token='*'
+            &&
+            (wildcard_pattern_var = wildcard_pattern_rule(p))  // wildcard_pattern
+        )
+        {
+            D(fprintf(stderr, "%*c+ star_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' wildcard_pattern"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_MatchRestOfSequence ( NULL , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s star_pattern[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'*' wildcard_pattern"));
     }
     _res = NULL;
   done:
@@ -6722,7 +7117,7 @@ star_pattern_rule(Parser *p)
 }
 
 // mapping_pattern: '{' items_pattern? '}'
-static expr_ty
+static pattern_ty
 mapping_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -6730,7 +7125,7 @@ mapping_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -6768,7 +7163,7 @@ mapping_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Dict ( CHECK ( asdl_expr_seq * , _PyPegen_get_keys ( p , items ) ) , CHECK ( asdl_expr_seq * , _PyPegen_get_values ( p , items ) ) , EXTRA );
+            _res = _PyAST_MatchMapping ( CHECK ( asdl_expr_seq * , _PyPegen_get_pattern_keys ( p , items ) ) , CHECK ( asdl_pattern_seq * , _PyPegen_get_patterns ( p , items ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6831,8 +7226,8 @@ items_pattern_rule(Parser *p)
     return _res;
 }
 
-// key_value_pattern: (literal_pattern | value_pattern) ':' pattern | double_star_pattern
-static KeyValuePair*
+// key_value_pattern: (literal_expr | attr) ':' pattern | double_star_pattern
+static KeyPatternPair*
 key_value_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -6840,27 +7235,27 @@ key_value_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    KeyValuePair* _res = NULL;
+    KeyPatternPair* _res = NULL;
     int _mark = p->mark;
-    { // (literal_pattern | value_pattern) ':' pattern
+    { // (literal_expr | attr) ':' pattern
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> key_value_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(literal_pattern | value_pattern) ':' pattern"));
+        D(fprintf(stderr, "%*c> key_value_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(literal_expr | attr) ':' pattern"));
         Token * _literal;
         void *key;
-        expr_ty value;
+        pattern_ty pattern;
         if (
-            (key = _tmp_61_rule(p))  // literal_pattern | value_pattern
+            (key = _tmp_61_rule(p))  // literal_expr | attr
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (value = pattern_rule(p))  // pattern
+            (pattern = pattern_rule(p))  // pattern
         )
         {
-            D(fprintf(stderr, "%*c+ key_value_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "(literal_pattern | value_pattern) ':' pattern"));
-            _res = _PyPegen_key_value_pair ( p , key , value );
+            D(fprintf(stderr, "%*c+ key_value_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "(literal_expr | attr) ':' pattern"));
+            _res = _PyPegen_key_pattern_pair ( p , key , pattern );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6870,7 +7265,7 @@ key_value_pattern_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s key_value_pattern[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(literal_pattern | value_pattern) ':' pattern"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(literal_expr | attr) ':' pattern"));
     }
     { // double_star_pattern
         if (p->error_indicator) {
@@ -6878,7 +7273,7 @@ key_value_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> key_value_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "double_star_pattern"));
-        KeyValuePair* double_star_pattern_var;
+        KeyPatternPair* double_star_pattern_var;
         if (
             (double_star_pattern_var = double_star_pattern_rule(p))  // double_star_pattern
         )
@@ -6897,8 +7292,8 @@ key_value_pattern_rule(Parser *p)
     return _res;
 }
 
-// double_star_pattern: '**' capture_pattern
-static KeyValuePair*
+// double_star_pattern: '**' pattern_capture_target
+static KeyPatternPair*
 double_star_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -6906,24 +7301,42 @@ double_star_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    KeyValuePair* _res = NULL;
+    KeyPatternPair* _res = NULL;
     int _mark = p->mark;
-    { // '**' capture_pattern
+    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
+        p->error_indicator = 1;
+        D(p->level--);
+        return NULL;
+    }
+    int _start_lineno = p->tokens[_mark]->lineno;
+    UNUSED(_start_lineno); // Only used by EXTRA macro
+    int _start_col_offset = p->tokens[_mark]->col_offset;
+    UNUSED(_start_col_offset); // Only used by EXTRA macro
+    { // '**' pattern_capture_target
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> double_star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**' capture_pattern"));
+        D(fprintf(stderr, "%*c> double_star_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'**' pattern_capture_target"));
         Token * _literal;
-        expr_ty value;
+        expr_ty target;
         if (
             (_literal = _PyPegen_expect_token(p, 35))  // token='**'
             &&
-            (value = capture_pattern_rule(p))  // capture_pattern
+            (target = pattern_capture_target_rule(p))  // pattern_capture_target
         )
         {
-            D(fprintf(stderr, "%*c+ double_star_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'**' capture_pattern"));
-            _res = _PyPegen_key_value_pair ( p , NULL , value );
+            D(fprintf(stderr, "%*c+ double_star_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'**' pattern_capture_target"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyPegen_key_pattern_pair ( p , NULL , _PyAST_MatchAs ( NULL , target -> v . Name . id , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6933,7 +7346,7 @@ double_star_pattern_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s double_star_pattern[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'**' capture_pattern"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'**' pattern_capture_target"));
     }
     _res = NULL;
   done:
@@ -6946,7 +7359,7 @@ double_star_pattern_rule(Parser *p)
 //     | name_or_attr '(' positional_patterns ','? ')'
 //     | name_or_attr '(' keyword_patterns ','? ')'
 //     | name_or_attr '(' positional_patterns ',' keyword_patterns ','? ')'
-static expr_ty
+static pattern_ty
 class_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -6954,7 +7367,7 @@ class_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    expr_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -6973,9 +7386,9 @@ class_pattern_rule(Parser *p)
         D(fprintf(stderr, "%*c> class_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "name_or_attr '(' ')'"));
         Token * _literal;
         Token * _literal_1;
-        expr_ty func;
+        expr_ty cls;
         if (
-            (func = name_or_attr_rule(p))  // name_or_attr
+            (cls = name_or_attr_rule(p))  // name_or_attr
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -6992,7 +7405,7 @@ class_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Call ( func , NULL , NULL , EXTRA );
+            _res = _PyAST_MatchClass ( cls , NULL , NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7014,14 +7427,14 @@ class_pattern_rule(Parser *p)
         Token * _literal_1;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_expr_seq* args;
-        expr_ty func;
+        expr_ty cls;
+        asdl_pattern_seq* patterns;
         if (
-            (func = name_or_attr_rule(p))  // name_or_attr
+            (cls = name_or_attr_rule(p))  // name_or_attr
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (args = positional_patterns_rule(p))  // positional_patterns
+            (patterns = positional_patterns_rule(p))  // positional_patterns
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
             &&
@@ -7038,7 +7451,7 @@ class_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Call ( func , args , NULL , EXTRA );
+            _res = _PyAST_MatchClass ( cls , patterns , NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7060,10 +7473,10 @@ class_pattern_rule(Parser *p)
         Token * _literal_1;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        expr_ty func;
-        asdl_keyword_seq* keywords;
+        expr_ty cls;
+        asdl_seq* keywords;
         if (
-            (func = name_or_attr_rule(p))  // name_or_attr
+            (cls = name_or_attr_rule(p))  // name_or_attr
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -7084,7 +7497,7 @@ class_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Call ( func , NULL , keywords , EXTRA );
+            _res = _PyAST_MatchClass ( cls , NULL , CHECK ( asdl_identifier_seq * , _PyPegen_map_names_to_ids ( p , CHECK ( asdl_expr_seq * , _PyPegen_get_pattern_keys ( p , keywords ) ) ) ) , CHECK ( asdl_pattern_seq * , _PyPegen_get_patterns ( p , keywords ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7107,15 +7520,15 @@ class_pattern_rule(Parser *p)
         Token * _literal_2;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_expr_seq* args;
-        expr_ty func;
-        asdl_keyword_seq* keywords;
+        expr_ty cls;
+        asdl_seq* keywords;
+        asdl_pattern_seq* patterns;
         if (
-            (func = name_or_attr_rule(p))  // name_or_attr
+            (cls = name_or_attr_rule(p))  // name_or_attr
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (args = positional_patterns_rule(p))  // positional_patterns
+            (patterns = positional_patterns_rule(p))  // positional_patterns
             &&
             (_literal_1 = _PyPegen_expect_token(p, 12))  // token=','
             &&
@@ -7136,7 +7549,7 @@ class_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_Call ( func , args , keywords , EXTRA );
+            _res = _PyAST_MatchClass ( cls , patterns , CHECK ( asdl_identifier_seq * , _PyPegen_map_names_to_ids ( p , CHECK ( asdl_expr_seq * , _PyPegen_get_pattern_keys ( p , keywords ) ) ) ) , CHECK ( asdl_pattern_seq * , _PyPegen_get_patterns ( p , keywords ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7155,7 +7568,7 @@ class_pattern_rule(Parser *p)
 }
 
 // positional_patterns: ','.pattern+
-static asdl_expr_seq*
+static asdl_pattern_seq*
 positional_patterns_rule(Parser *p)
 {
     D(p->level++);
@@ -7163,7 +7576,7 @@ positional_patterns_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_expr_seq* _res = NULL;
+    asdl_pattern_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.pattern+
         if (p->error_indicator) {
@@ -7171,9 +7584,9 @@ positional_patterns_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> positional_patterns[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.pattern+"));
-        asdl_expr_seq* args;
+        asdl_pattern_seq* args;
         if (
-            (args = (asdl_expr_seq*)_gather_62_rule(p))  // ','.pattern+
+            (args = (asdl_pattern_seq*)_gather_62_rule(p))  // ','.pattern+
         )
         {
             D(fprintf(stderr, "%*c+ positional_patterns[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.pattern+"));
@@ -7196,7 +7609,7 @@ positional_patterns_rule(Parser *p)
 }
 
 // keyword_patterns: ','.keyword_pattern+
-static asdl_keyword_seq*
+static asdl_seq*
 keyword_patterns_rule(Parser *p)
 {
     D(p->level++);
@@ -7204,7 +7617,7 @@ keyword_patterns_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_keyword_seq* _res = NULL;
+    asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.keyword_pattern+
         if (p->error_indicator) {
@@ -7212,9 +7625,9 @@ keyword_patterns_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> keyword_patterns[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.keyword_pattern+"));
-        asdl_keyword_seq* keywords;
+        asdl_seq* keywords;
         if (
-            (keywords = (asdl_keyword_seq*)_gather_64_rule(p))  // ','.keyword_pattern+
+            (keywords = (asdl_seq*)_gather_64_rule(p))  // ','.keyword_pattern+
         )
         {
             D(fprintf(stderr, "%*c+ keyword_patterns[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.keyword_pattern+"));
@@ -7237,7 +7650,7 @@ keyword_patterns_rule(Parser *p)
 }
 
 // keyword_pattern: NAME '=' pattern
-static keyword_ty
+static pattern_ty
 keyword_pattern_rule(Parser *p)
 {
     D(p->level++);
@@ -7245,17 +7658,8 @@ keyword_pattern_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    keyword_ty _res = NULL;
+    pattern_ty _res = NULL;
     int _mark = p->mark;
-    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
-        p->error_indicator = 1;
-        D(p->level--);
-        return NULL;
-    }
-    int _start_lineno = p->tokens[_mark]->lineno;
-    UNUSED(_start_lineno); // Only used by EXTRA macro
-    int _start_col_offset = p->tokens[_mark]->col_offset;
-    UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME '=' pattern
         if (p->error_indicator) {
             D(p->level--);
@@ -7264,7 +7668,7 @@ keyword_pattern_rule(Parser *p)
         D(fprintf(stderr, "%*c> keyword_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME '=' pattern"));
         Token * _literal;
         expr_ty arg;
-        expr_ty value;
+        pattern_ty value;
         if (
             (arg = _PyPegen_name_token(p))  // NAME
             &&
@@ -7274,16 +7678,7 @@ keyword_pattern_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ keyword_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME '=' pattern"));
-            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
-            if (_token == NULL) {
-                D(p->level--);
-                return NULL;
-            }
-            int _end_lineno = _token->end_lineno;
-            UNUSED(_end_lineno); // Only used by EXTRA macro
-            int _end_col_offset = _token->end_col_offset;
-            UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_keyword ( arg -> v . Name . id , value , EXTRA );
+            _res = _PyPegen_key_pattern_pair ( p , arg , value );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -19076,7 +19471,7 @@ invalid_case_block_rule(Parser *p)
         expr_ty _keyword;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        expr_ty patterns_var;
+        pattern_ty patterns_var;
         if (
             (_keyword = _PyPegen_expect_soft_keyword(p, "case"))  // soft_keyword='"case"'
             &&
@@ -22383,7 +22778,7 @@ _loop0_52_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _loop0_52[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'|' closed_pattern"));
         Token * _literal;
-        expr_ty elem;
+        pattern_ty elem;
         while (
             (_literal = _PyPegen_expect_token(p, 18))  // token='|'
             &&
@@ -22447,7 +22842,7 @@ _gather_51_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_51[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "closed_pattern _loop0_52"));
-        expr_ty elem;
+        pattern_ty elem;
         asdl_seq * seq;
         if (
             (elem = closed_pattern_rule(p))  // closed_pattern
@@ -22524,7 +22919,7 @@ _tmp_53_rule(Parser *p)
     return _res;
 }
 
-// _tmp_54: '.' | '(' | '='
+// _tmp_54: '+' | '-'
 static void *
 _tmp_54_rule(Parser *p)
 {
@@ -22535,62 +22930,43 @@ _tmp_54_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
-    { // '.'
+    { // '+'
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_54[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'.'"));
+        D(fprintf(stderr, "%*c> _tmp_54[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'+'"));
         Token * _literal;
         if (
-            (_literal = _PyPegen_expect_token(p, 23))  // token='.'
+            (_literal = _PyPegen_expect_token(p, 14))  // token='+'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_54[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'.'"));
+            D(fprintf(stderr, "%*c+ _tmp_54[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'+'"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _tmp_54[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'.'"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'+'"));
     }
-    { // '('
+    { // '-'
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_54[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'('"));
+        D(fprintf(stderr, "%*c> _tmp_54[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'-'"));
         Token * _literal;
         if (
-            (_literal = _PyPegen_expect_token(p, 7))  // token='('
+            (_literal = _PyPegen_expect_token(p, 15))  // token='-'
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_54[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'('"));
+            D(fprintf(stderr, "%*c+ _tmp_54[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'-'"));
             _res = _literal;
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _tmp_54[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'('"));
-    }
-    { // '='
-        if (p->error_indicator) {
-            D(p->level--);
-            return NULL;
-        }
-        D(fprintf(stderr, "%*c> _tmp_54[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'='"));
-        Token * _literal;
-        if (
-            (_literal = _PyPegen_expect_token(p, 22))  // token='='
-        )
-        {
-            D(fprintf(stderr, "%*c+ _tmp_54[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'='"));
-            _res = _literal;
-            goto done;
-        }
-        p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_54[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'='"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'-'"));
     }
     _res = NULL;
   done:
@@ -22672,9 +23048,83 @@ _tmp_55_rule(Parser *p)
     return _res;
 }
 
-// _loop0_57: ',' maybe_star_pattern
+// _tmp_56: '.' | '(' | '='
+static void *
+_tmp_56_rule(Parser *p)
+{
+    D(p->level++);
+    if (p->error_indicator) {
+        D(p->level--);
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // '.'
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_56[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'.'"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 23))  // token='.'
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_56[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'.'"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_56[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'.'"));
+    }
+    { // '('
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_56[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'('"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 7))  // token='('
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_56[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'('"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_56[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'('"));
+    }
+    { // '='
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> _tmp_56[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'='"));
+        Token * _literal;
+        if (
+            (_literal = _PyPegen_expect_token(p, 22))  // token='='
+        )
+        {
+            D(fprintf(stderr, "%*c+ _tmp_56[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'='"));
+            _res = _literal;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s _tmp_56[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'='"));
+    }
+    _res = NULL;
+  done:
+    D(p->level--);
+    return _res;
+}
+
+// _loop0_58: ',' maybe_star_pattern
 static asdl_seq *
-_loop0_57_rule(Parser *p)
+_loop0_58_rule(Parser *p)
 {
     D(p->level++);
     if (p->error_indicator) {
@@ -22698,9 +23148,9 @@ _loop0_57_rule(Parser *p)
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _loop0_57[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' maybe_star_pattern"));
+        D(fprintf(stderr, "%*c> _loop0_58[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' maybe_star_pattern"));
         Token * _literal;
-        expr_ty elem;
+        pattern_ty elem;
         while (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
@@ -22729,7 +23179,7 @@ _loop0_57_rule(Parser *p)
             _mark = p->mark;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _loop0_57[%d-%d]: %s failed!\n", p->level, ' ',
+        D(fprintf(stderr, "%*c%s _loop0_58[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' maybe_star_pattern"));
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
@@ -22742,14 +23192,14 @@ _loop0_57_rule(Parser *p)
     }
     for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
-    _PyPegen_insert_memo(p, _start_mark, _loop0_57_type, _seq);
+    _PyPegen_insert_memo(p, _start_mark, _loop0_58_type, _seq);
     D(p->level--);
     return _seq;
 }
 
-// _gather_56: maybe_star_pattern _loop0_57
+// _gather_57: maybe_star_pattern _loop0_58
 static asdl_seq *
-_gather_56_rule(Parser *p)
+_gather_57_rule(Parser *p)
 {
     D(p->level++);
     if (p->error_indicator) {
@@ -22758,82 +23208,27 @@ _gather_56_rule(Parser *p)
     }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
-    { // maybe_star_pattern _loop0_57
+    { // maybe_star_pattern _loop0_58
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _gather_56[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "maybe_star_pattern _loop0_57"));
-        expr_ty elem;
+        D(fprintf(stderr, "%*c> _gather_57[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "maybe_star_pattern _loop0_58"));
+        pattern_ty elem;
         asdl_seq * seq;
         if (
             (elem = maybe_star_pattern_rule(p))  // maybe_star_pattern
             &&
-            (seq = _loop0_57_rule(p))  // _loop0_57
+            (seq = _loop0_58_rule(p))  // _loop0_58
         )
         {
-            D(fprintf(stderr, "%*c+ _gather_56[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "maybe_star_pattern _loop0_57"));
+            D(fprintf(stderr, "%*c+ _gather_57[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "maybe_star_pattern _loop0_58"));
             _res = _PyPegen_seq_insert_in_front(p, elem, seq);
             goto done;
         }
         p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _gather_56[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "maybe_star_pattern _loop0_57"));
-    }
-    _res = NULL;
-  done:
-    D(p->level--);
-    return _res;
-}
-
-// _tmp_58: capture_pattern | wildcard_pattern
-static void *
-_tmp_58_rule(Parser *p)
-{
-    D(p->level++);
-    if (p->error_indicator) {
-        D(p->level--);
-        return NULL;
-    }
-    void * _res = NULL;
-    int _mark = p->mark;
-    { // capture_pattern
-        if (p->error_indicator) {
-            D(p->level--);
-            return NULL;
-        }
-        D(fprintf(stderr, "%*c> _tmp_58[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "capture_pattern"));
-        expr_ty capture_pattern_var;
-        if (
-            (capture_pattern_var = capture_pattern_rule(p))  // capture_pattern
-        )
-        {
-            D(fprintf(stderr, "%*c+ _tmp_58[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "capture_pattern"));
-            _res = capture_pattern_var;
-            goto done;
-        }
-        p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_58[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "capture_pattern"));
-    }
-    { // wildcard_pattern
-        if (p->error_indicator) {
-            D(p->level--);
-            return NULL;
-        }
-        D(fprintf(stderr, "%*c> _tmp_58[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "wildcard_pattern"));
-        expr_ty wildcard_pattern_var;
-        if (
-            (wildcard_pattern_var = wildcard_pattern_rule(p))  // wildcard_pattern
-        )
-        {
-            D(fprintf(stderr, "%*c+ _tmp_58[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "wildcard_pattern"));
-            _res = wildcard_pattern_var;
-            goto done;
-        }
-        p->mark = _mark;
-        D(fprintf(stderr, "%*c%s _tmp_58[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "wildcard_pattern"));
+        D(fprintf(stderr, "%*c%s _gather_57[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "maybe_star_pattern _loop0_58"));
     }
     _res = NULL;
   done:
@@ -22869,7 +23264,7 @@ _loop0_60_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _loop0_60[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' key_value_pattern"));
         Token * _literal;
-        KeyValuePair* elem;
+        KeyPatternPair* elem;
         while (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
@@ -22933,7 +23328,7 @@ _gather_59_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_59[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "key_value_pattern _loop0_60"));
-        KeyValuePair* elem;
+        KeyPatternPair* elem;
         asdl_seq * seq;
         if (
             (elem = key_value_pattern_rule(p))  // key_value_pattern
@@ -22955,7 +23350,7 @@ _gather_59_rule(Parser *p)
     return _res;
 }
 
-// _tmp_61: literal_pattern | value_pattern
+// _tmp_61: literal_expr | attr
 static void *
 _tmp_61_rule(Parser *p)
 {
@@ -22966,43 +23361,43 @@ _tmp_61_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
-    { // literal_pattern
+    { // literal_expr
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_61[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "literal_pattern"));
-        expr_ty literal_pattern_var;
+        D(fprintf(stderr, "%*c> _tmp_61[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "literal_expr"));
+        expr_ty literal_expr_var;
         if (
-            (literal_pattern_var = literal_pattern_rule(p))  // literal_pattern
+            (literal_expr_var = literal_expr_rule(p))  // literal_expr
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_61[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "literal_pattern"));
-            _res = literal_pattern_var;
+            D(fprintf(stderr, "%*c+ _tmp_61[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "literal_expr"));
+            _res = literal_expr_var;
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _tmp_61[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "literal_pattern"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "literal_expr"));
     }
-    { // value_pattern
+    { // attr
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> _tmp_61[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "value_pattern"));
-        expr_ty value_pattern_var;
+        D(fprintf(stderr, "%*c> _tmp_61[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "attr"));
+        expr_ty attr_var;
         if (
-            (value_pattern_var = value_pattern_rule(p))  // value_pattern
+            (attr_var = attr_rule(p))  // attr
         )
         {
-            D(fprintf(stderr, "%*c+ _tmp_61[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "value_pattern"));
-            _res = value_pattern_var;
+            D(fprintf(stderr, "%*c+ _tmp_61[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "attr"));
+            _res = attr_var;
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _tmp_61[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "value_pattern"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "attr"));
     }
     _res = NULL;
   done:
@@ -23038,7 +23433,7 @@ _loop0_63_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _loop0_63[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' pattern"));
         Token * _literal;
-        expr_ty elem;
+        pattern_ty elem;
         while (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
@@ -23102,7 +23497,7 @@ _gather_62_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_62[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "pattern _loop0_63"));
-        expr_ty elem;
+        pattern_ty elem;
         asdl_seq * seq;
         if (
             (elem = pattern_rule(p))  // pattern
@@ -23152,7 +23547,7 @@ _loop0_65_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _loop0_65[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "',' keyword_pattern"));
         Token * _literal;
-        keyword_ty elem;
+        pattern_ty elem;
         while (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
@@ -23216,7 +23611,7 @@ _gather_64_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _gather_64[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "keyword_pattern _loop0_65"));
-        keyword_ty elem;
+        pattern_ty elem;
         asdl_seq * seq;
         if (
             (elem = keyword_pattern_rule(p))  // keyword_pattern

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1794,6 +1794,51 @@ _PyPegen_get_values(Parser *p, asdl_seq *seq)
     return new_seq;
 }
 
+/* Constructs a KeyPatternPair that is used when parsing a mapping pattern */
+KeyPatternPair *
+_PyPegen_key_pattern_pair(Parser *p, expr_ty key, pattern_ty pattern)
+{
+    KeyPatternPair *a = _PyArena_Malloc(p->arena, sizeof(KeyPatternPair));
+    if (!a) {
+        return NULL;
+    }
+    a->key = key;
+    a->pattern = pattern;
+    return a;
+}
+
+/* Extracts all keys from an asdl_seq* of KeyPatternPair*'s */
+asdl_expr_seq *
+_PyPegen_get_pattern_keys(Parser *p, asdl_seq *seq)
+{
+    Py_ssize_t len = asdl_seq_LEN(seq);
+    asdl_expr_seq *new_seq = _Py_asdl_expr_seq_new(len, p->arena);
+    if (!new_seq) {
+        return NULL;
+    }
+    for (Py_ssize_t i = 0; i < len; i++) {
+        KeyPatternPair *pair = asdl_seq_GET_UNTYPED(seq, i);
+        asdl_seq_SET(new_seq, i, pair->key);
+    }
+    return new_seq;
+}
+
+/* Extracts all patterns from an asdl_seq* of KeyPatternPair*'s */
+asdl_pattern_seq *
+_PyPegen_get_patterns(Parser *p, asdl_seq *seq)
+{
+    Py_ssize_t len = asdl_seq_LEN(seq);
+    asdl_pattern_seq *new_seq = _Py_asdl_pattern_seq_new(len, p->arena);
+    if (!new_seq) {
+        return NULL;
+    }
+    for (Py_ssize_t i = 0; i < len; i++) {
+        KeyPatternPair *pair = asdl_seq_GET_UNTYPED(seq, i);
+        asdl_seq_SET(new_seq, i, pair->pattern);
+    }
+    return new_seq;
+}
+
 /* Constructs a NameDefaultPair */
 NameDefaultPair *
 _PyPegen_name_default_pair(Parser *p, arg_ty arg, expr_ty value, Token *tc)

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -87,6 +87,11 @@ typedef struct {
 } KeyValuePair;
 
 typedef struct {
+    expr_ty key;
+    pattern_ty pattern;
+} KeyPatternPair;
+
+typedef struct {
     arg_ty arg;
     expr_ty value;
 } NameDefaultPair;
@@ -248,6 +253,9 @@ expr_ty _PyPegen_set_expr_context(Parser *, expr_ty, expr_context_ty);
 KeyValuePair *_PyPegen_key_value_pair(Parser *, expr_ty, expr_ty);
 asdl_expr_seq *_PyPegen_get_keys(Parser *, asdl_seq *);
 asdl_expr_seq *_PyPegen_get_values(Parser *, asdl_seq *);
+KeyPatternPair *_PyPegen_key_pattern_pair(Parser *, expr_ty, pattern_ty);
+asdl_expr_seq *_PyPegen_get_pattern_keys(Parser *, asdl_seq *);
+asdl_pattern_seq *_PyPegen_get_patterns(Parser *, asdl_seq *);
 NameDefaultPair *_PyPegen_name_default_pair(Parser *, arg_ty, expr_ty, Token *);
 SlashWithDefault *_PyPegen_slash_with_default(Parser *, asdl_arg_seq *, asdl_seq *);
 StarEtc *_PyPegen_star_etc(Parser *, arg_ty, asdl_seq *, arg_ty);

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -105,8 +105,15 @@ void _PyAST_Fini(PyInterpreterState *interp)
     Py_CLEAR(state->Lt_type);
     Py_CLEAR(state->MatMult_singleton);
     Py_CLEAR(state->MatMult_type);
+    Py_CLEAR(state->MatchAlways_type);
     Py_CLEAR(state->MatchAs_type);
+    Py_CLEAR(state->MatchClass_type);
+    Py_CLEAR(state->MatchConstant_type);
+    Py_CLEAR(state->MatchMapping_type);
     Py_CLEAR(state->MatchOr_type);
+    Py_CLEAR(state->MatchRestOfSequence_type);
+    Py_CLEAR(state->MatchSequence_type);
+    Py_CLEAR(state->MatchValue_type);
     Py_CLEAR(state->Match_type);
     Py_CLEAR(state->Mod_singleton);
     Py_CLEAR(state->Mod_type);
@@ -173,6 +180,7 @@ void _PyAST_Fini(PyInterpreterState *interp)
     Py_CLEAR(state->boolop_type);
     Py_CLEAR(state->cases);
     Py_CLEAR(state->cause);
+    Py_CLEAR(state->cls);
     Py_CLEAR(state->cmpop_type);
     Py_CLEAR(state->col_offset);
     Py_CLEAR(state->comparators);
@@ -190,6 +198,8 @@ void _PyAST_Fini(PyInterpreterState *interp)
     Py_CLEAR(state->excepthandler_type);
     Py_CLEAR(state->expr_context_type);
     Py_CLEAR(state->expr_type);
+    Py_CLEAR(state->extra_attrs);
+    Py_CLEAR(state->extra_patterns);
     Py_CLEAR(state->finalbody);
     Py_CLEAR(state->format_spec);
     Py_CLEAR(state->func);
@@ -226,6 +236,7 @@ void _PyAST_Fini(PyInterpreterState *interp)
     Py_CLEAR(state->optional_vars);
     Py_CLEAR(state->orelse);
     Py_CLEAR(state->pattern);
+    Py_CLEAR(state->pattern_type);
     Py_CLEAR(state->patterns);
     Py_CLEAR(state->posonlyargs);
     Py_CLEAR(state->returns);
@@ -276,6 +287,7 @@ static int init_identifiers(struct ast_state *state)
     if ((state->body = PyUnicode_InternFromString("body")) == NULL) return 0;
     if ((state->cases = PyUnicode_InternFromString("cases")) == NULL) return 0;
     if ((state->cause = PyUnicode_InternFromString("cause")) == NULL) return 0;
+    if ((state->cls = PyUnicode_InternFromString("cls")) == NULL) return 0;
     if ((state->col_offset = PyUnicode_InternFromString("col_offset")) == NULL) return 0;
     if ((state->comparators = PyUnicode_InternFromString("comparators")) == NULL) return 0;
     if ((state->context_expr = PyUnicode_InternFromString("context_expr")) == NULL) return 0;
@@ -288,6 +300,8 @@ static int init_identifiers(struct ast_state *state)
     if ((state->end_col_offset = PyUnicode_InternFromString("end_col_offset")) == NULL) return 0;
     if ((state->end_lineno = PyUnicode_InternFromString("end_lineno")) == NULL) return 0;
     if ((state->exc = PyUnicode_InternFromString("exc")) == NULL) return 0;
+    if ((state->extra_attrs = PyUnicode_InternFromString("extra_attrs")) == NULL) return 0;
+    if ((state->extra_patterns = PyUnicode_InternFromString("extra_patterns")) == NULL) return 0;
     if ((state->finalbody = PyUnicode_InternFromString("finalbody")) == NULL) return 0;
     if ((state->format_spec = PyUnicode_InternFromString("format_spec")) == NULL) return 0;
     if ((state->func = PyUnicode_InternFromString("func")) == NULL) return 0;
@@ -353,6 +367,7 @@ GENERATE_ASDL_SEQ_CONSTRUCTOR(keyword, keyword_ty)
 GENERATE_ASDL_SEQ_CONSTRUCTOR(alias, alias_ty)
 GENERATE_ASDL_SEQ_CONSTRUCTOR(withitem, withitem_ty)
 GENERATE_ASDL_SEQ_CONSTRUCTOR(match_case, match_case_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(pattern, pattern_ty)
 GENERATE_ASDL_SEQ_CONSTRUCTOR(type_ignore, type_ignore_ty)
 
 static PyObject* ast2obj_mod(struct ast_state *state, void*);
@@ -610,13 +625,6 @@ static const char * const Slice_fields[]={
     "upper",
     "step",
 };
-static const char * const MatchAs_fields[]={
-    "pattern",
-    "name",
-};
-static const char * const MatchOr_fields[]={
-    "patterns",
-};
 static PyObject* ast2obj_expr_context(struct ast_state *state, expr_context_ty);
 static PyObject* ast2obj_boolop(struct ast_state *state, boolop_ty);
 static PyObject* ast2obj_operator(struct ast_state *state, operator_ty);
@@ -695,6 +703,42 @@ static const char * const match_case_fields[]={
     "pattern",
     "guard",
     "body",
+};
+static const char * const pattern_attributes[] = {
+    "lineno",
+    "col_offset",
+    "end_lineno",
+    "end_col_offset",
+};
+static PyObject* ast2obj_pattern(struct ast_state *state, void*);
+static const char * const MatchValue_fields[]={
+    "value",
+};
+static const char * const MatchConstant_fields[]={
+    "value",
+};
+static const char * const MatchSequence_fields[]={
+    "patterns",
+};
+static const char * const MatchMapping_fields[]={
+    "keys",
+    "patterns",
+};
+static const char * const MatchClass_fields[]={
+    "cls",
+    "patterns",
+    "extra_attrs",
+    "extra_patterns",
+};
+static const char * const MatchRestOfSequence_fields[]={
+    "target",
+};
+static const char * const MatchAs_fields[]={
+    "pattern",
+    "target",
+};
+static const char * const MatchOr_fields[]={
+    "patterns",
 };
 static PyObject* ast2obj_type_ignore(struct ast_state *state, void*);
 static const char * const TypeIgnore_fields[]={
@@ -1275,9 +1319,7 @@ init_types(struct ast_state *state)
         "     | Name(identifier id, expr_context ctx)\n"
         "     | List(expr* elts, expr_context ctx)\n"
         "     | Tuple(expr* elts, expr_context ctx)\n"
-        "     | Slice(expr? lower, expr? upper, expr? step)\n"
-        "     | MatchAs(expr pattern, identifier name)\n"
-        "     | MatchOr(expr* patterns)");
+        "     | Slice(expr? lower, expr? upper, expr? step)");
     if (!state->expr_type) return 0;
     if (!add_attributes(state, state->expr_type, expr_attributes, 4)) return 0;
     if (PyObject_SetAttr(state->expr_type, state->end_lineno, Py_None) == -1)
@@ -1410,14 +1452,6 @@ init_types(struct ast_state *state)
         return 0;
     if (PyObject_SetAttr(state->Slice_type, state->step, Py_None) == -1)
         return 0;
-    state->MatchAs_type = make_type(state, "MatchAs", state->expr_type,
-                                    MatchAs_fields, 2,
-        "MatchAs(expr pattern, identifier name)");
-    if (!state->MatchAs_type) return 0;
-    state->MatchOr_type = make_type(state, "MatchOr", state->expr_type,
-                                    MatchOr_fields, 1,
-        "MatchOr(expr* patterns)");
-    if (!state->MatchOr_type) return 0;
     state->expr_context_type = make_type(state, "expr_context",
                                          state->AST_type, NULL, 0,
         "expr_context = Load | Store | Del");
@@ -1732,11 +1766,76 @@ init_types(struct ast_state *state)
         return 0;
     state->match_case_type = make_type(state, "match_case", state->AST_type,
                                        match_case_fields, 3,
-        "match_case(expr pattern, expr? guard, stmt* body)");
+        "match_case(pattern pattern, expr? guard, stmt* body)");
     if (!state->match_case_type) return 0;
     if (!add_attributes(state, state->match_case_type, NULL, 0)) return 0;
     if (PyObject_SetAttr(state->match_case_type, state->guard, Py_None) == -1)
         return 0;
+    state->pattern_type = make_type(state, "pattern", state->AST_type, NULL, 0,
+        "pattern = MatchAlways\n"
+        "        | MatchValue(expr value)\n"
+        "        | MatchConstant(constant value)\n"
+        "        | MatchSequence(pattern* patterns)\n"
+        "        | MatchMapping(expr* keys, pattern* patterns)\n"
+        "        | MatchClass(expr cls, pattern* patterns, identifier* extra_attrs, pattern* extra_patterns)\n"
+        "        | MatchRestOfSequence(identifier? target)\n"
+        "        | MatchAs(pattern? pattern, identifier target)\n"
+        "        | MatchOr(pattern* patterns)");
+    if (!state->pattern_type) return 0;
+    if (!add_attributes(state, state->pattern_type, pattern_attributes, 4))
+        return 0;
+    if (PyObject_SetAttr(state->pattern_type, state->end_lineno, Py_None) == -1)
+        return 0;
+    if (PyObject_SetAttr(state->pattern_type, state->end_col_offset, Py_None)
+        == -1)
+        return 0;
+    state->MatchAlways_type = make_type(state, "MatchAlways",
+                                        state->pattern_type, NULL, 0,
+        "MatchAlways");
+    if (!state->MatchAlways_type) return 0;
+    state->MatchValue_type = make_type(state, "MatchValue",
+                                       state->pattern_type, MatchValue_fields,
+                                       1,
+        "MatchValue(expr value)");
+    if (!state->MatchValue_type) return 0;
+    state->MatchConstant_type = make_type(state, "MatchConstant",
+                                          state->pattern_type,
+                                          MatchConstant_fields, 1,
+        "MatchConstant(constant value)");
+    if (!state->MatchConstant_type) return 0;
+    state->MatchSequence_type = make_type(state, "MatchSequence",
+                                          state->pattern_type,
+                                          MatchSequence_fields, 1,
+        "MatchSequence(pattern* patterns)");
+    if (!state->MatchSequence_type) return 0;
+    state->MatchMapping_type = make_type(state, "MatchMapping",
+                                         state->pattern_type,
+                                         MatchMapping_fields, 2,
+        "MatchMapping(expr* keys, pattern* patterns)");
+    if (!state->MatchMapping_type) return 0;
+    state->MatchClass_type = make_type(state, "MatchClass",
+                                       state->pattern_type, MatchClass_fields,
+                                       4,
+        "MatchClass(expr cls, pattern* patterns, identifier* extra_attrs, pattern* extra_patterns)");
+    if (!state->MatchClass_type) return 0;
+    state->MatchRestOfSequence_type = make_type(state, "MatchRestOfSequence",
+                                                state->pattern_type,
+                                                MatchRestOfSequence_fields, 1,
+        "MatchRestOfSequence(identifier? target)");
+    if (!state->MatchRestOfSequence_type) return 0;
+    if (PyObject_SetAttr(state->MatchRestOfSequence_type, state->target,
+        Py_None) == -1)
+        return 0;
+    state->MatchAs_type = make_type(state, "MatchAs", state->pattern_type,
+                                    MatchAs_fields, 2,
+        "MatchAs(pattern? pattern, identifier target)");
+    if (!state->MatchAs_type) return 0;
+    if (PyObject_SetAttr(state->MatchAs_type, state->pattern, Py_None) == -1)
+        return 0;
+    state->MatchOr_type = make_type(state, "MatchOr", state->pattern_type,
+                                    MatchOr_fields, 1,
+        "MatchOr(pattern* patterns)");
+    if (!state->MatchOr_type) return 0;
     state->type_ignore_type = make_type(state, "type_ignore", state->AST_type,
                                         NULL, 0,
         "type_ignore = TypeIgnore(int lineno, string tag)");
@@ -1784,6 +1883,8 @@ static int obj2ast_withitem(struct ast_state *state, PyObject* obj,
                             withitem_ty* out, PyArena* arena);
 static int obj2ast_match_case(struct ast_state *state, PyObject* obj,
                               match_case_ty* out, PyArena* arena);
+static int obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty*
+                           out, PyArena* arena);
 static int obj2ast_type_ignore(struct ast_state *state, PyObject* obj,
                                type_ignore_ty* out, PyArena* arena);
 
@@ -3127,51 +3228,6 @@ _PyAST_Slice(expr_ty lower, expr_ty upper, expr_ty step, int lineno, int
     return p;
 }
 
-expr_ty
-_PyAST_MatchAs(expr_ty pattern, identifier name, int lineno, int col_offset,
-               int end_lineno, int end_col_offset, PyArena *arena)
-{
-    expr_ty p;
-    if (!pattern) {
-        PyErr_SetString(PyExc_ValueError,
-                        "field 'pattern' is required for MatchAs");
-        return NULL;
-    }
-    if (!name) {
-        PyErr_SetString(PyExc_ValueError,
-                        "field 'name' is required for MatchAs");
-        return NULL;
-    }
-    p = (expr_ty)_PyArena_Malloc(arena, sizeof(*p));
-    if (!p)
-        return NULL;
-    p->kind = MatchAs_kind;
-    p->v.MatchAs.pattern = pattern;
-    p->v.MatchAs.name = name;
-    p->lineno = lineno;
-    p->col_offset = col_offset;
-    p->end_lineno = end_lineno;
-    p->end_col_offset = end_col_offset;
-    return p;
-}
-
-expr_ty
-_PyAST_MatchOr(asdl_expr_seq * patterns, int lineno, int col_offset, int
-               end_lineno, int end_col_offset, PyArena *arena)
-{
-    expr_ty p;
-    p = (expr_ty)_PyArena_Malloc(arena, sizeof(*p));
-    if (!p)
-        return NULL;
-    p->kind = MatchOr_kind;
-    p->v.MatchOr.patterns = patterns;
-    p->lineno = lineno;
-    p->col_offset = col_offset;
-    p->end_lineno = end_lineno;
-    p->end_col_offset = end_col_offset;
-    return p;
-}
-
 comprehension_ty
 _PyAST_comprehension(expr_ty target, expr_ty iter, asdl_expr_seq * ifs, int
                      is_async, PyArena *arena)
@@ -3322,8 +3378,8 @@ _PyAST_withitem(expr_ty context_expr, expr_ty optional_vars, PyArena *arena)
 }
 
 match_case_ty
-_PyAST_match_case(expr_ty pattern, expr_ty guard, asdl_stmt_seq * body, PyArena
-                  *arena)
+_PyAST_match_case(pattern_ty pattern, expr_ty guard, asdl_stmt_seq * body,
+                  PyArena *arena)
 {
     match_case_ty p;
     if (!pattern) {
@@ -3337,6 +3393,186 @@ _PyAST_match_case(expr_ty pattern, expr_ty guard, asdl_stmt_seq * body, PyArena
     p->pattern = pattern;
     p->guard = guard;
     p->body = body;
+    return p;
+}
+
+pattern_ty
+_PyAST_MatchAlways(int lineno, int col_offset, int end_lineno, int
+                   end_col_offset, PyArena *arena)
+{
+    pattern_ty p;
+    p = (pattern_ty)_PyArena_Malloc(arena, sizeof(*p));
+    if (!p)
+        return NULL;
+    p->kind = MatchAlways_kind;
+    p->lineno = lineno;
+    p->col_offset = col_offset;
+    p->end_lineno = end_lineno;
+    p->end_col_offset = end_col_offset;
+    return p;
+}
+
+pattern_ty
+_PyAST_MatchValue(expr_ty value, int lineno, int col_offset, int end_lineno,
+                  int end_col_offset, PyArena *arena)
+{
+    pattern_ty p;
+    if (!value) {
+        PyErr_SetString(PyExc_ValueError,
+                        "field 'value' is required for MatchValue");
+        return NULL;
+    }
+    p = (pattern_ty)_PyArena_Malloc(arena, sizeof(*p));
+    if (!p)
+        return NULL;
+    p->kind = MatchValue_kind;
+    p->v.MatchValue.value = value;
+    p->lineno = lineno;
+    p->col_offset = col_offset;
+    p->end_lineno = end_lineno;
+    p->end_col_offset = end_col_offset;
+    return p;
+}
+
+pattern_ty
+_PyAST_MatchConstant(constant value, int lineno, int col_offset, int
+                     end_lineno, int end_col_offset, PyArena *arena)
+{
+    pattern_ty p;
+    if (!value) {
+        PyErr_SetString(PyExc_ValueError,
+                        "field 'value' is required for MatchConstant");
+        return NULL;
+    }
+    p = (pattern_ty)_PyArena_Malloc(arena, sizeof(*p));
+    if (!p)
+        return NULL;
+    p->kind = MatchConstant_kind;
+    p->v.MatchConstant.value = value;
+    p->lineno = lineno;
+    p->col_offset = col_offset;
+    p->end_lineno = end_lineno;
+    p->end_col_offset = end_col_offset;
+    return p;
+}
+
+pattern_ty
+_PyAST_MatchSequence(asdl_pattern_seq * patterns, int lineno, int col_offset,
+                     int end_lineno, int end_col_offset, PyArena *arena)
+{
+    pattern_ty p;
+    p = (pattern_ty)_PyArena_Malloc(arena, sizeof(*p));
+    if (!p)
+        return NULL;
+    p->kind = MatchSequence_kind;
+    p->v.MatchSequence.patterns = patterns;
+    p->lineno = lineno;
+    p->col_offset = col_offset;
+    p->end_lineno = end_lineno;
+    p->end_col_offset = end_col_offset;
+    return p;
+}
+
+pattern_ty
+_PyAST_MatchMapping(asdl_expr_seq * keys, asdl_pattern_seq * patterns, int
+                    lineno, int col_offset, int end_lineno, int end_col_offset,
+                    PyArena *arena)
+{
+    pattern_ty p;
+    p = (pattern_ty)_PyArena_Malloc(arena, sizeof(*p));
+    if (!p)
+        return NULL;
+    p->kind = MatchMapping_kind;
+    p->v.MatchMapping.keys = keys;
+    p->v.MatchMapping.patterns = patterns;
+    p->lineno = lineno;
+    p->col_offset = col_offset;
+    p->end_lineno = end_lineno;
+    p->end_col_offset = end_col_offset;
+    return p;
+}
+
+pattern_ty
+_PyAST_MatchClass(expr_ty cls, asdl_pattern_seq * patterns, asdl_identifier_seq
+                  * extra_attrs, asdl_pattern_seq * extra_patterns, int lineno,
+                  int col_offset, int end_lineno, int end_col_offset, PyArena
+                  *arena)
+{
+    pattern_ty p;
+    if (!cls) {
+        PyErr_SetString(PyExc_ValueError,
+                        "field 'cls' is required for MatchClass");
+        return NULL;
+    }
+    p = (pattern_ty)_PyArena_Malloc(arena, sizeof(*p));
+    if (!p)
+        return NULL;
+    p->kind = MatchClass_kind;
+    p->v.MatchClass.cls = cls;
+    p->v.MatchClass.patterns = patterns;
+    p->v.MatchClass.extra_attrs = extra_attrs;
+    p->v.MatchClass.extra_patterns = extra_patterns;
+    p->lineno = lineno;
+    p->col_offset = col_offset;
+    p->end_lineno = end_lineno;
+    p->end_col_offset = end_col_offset;
+    return p;
+}
+
+pattern_ty
+_PyAST_MatchRestOfSequence(identifier target, int lineno, int col_offset, int
+                           end_lineno, int end_col_offset, PyArena *arena)
+{
+    pattern_ty p;
+    p = (pattern_ty)_PyArena_Malloc(arena, sizeof(*p));
+    if (!p)
+        return NULL;
+    p->kind = MatchRestOfSequence_kind;
+    p->v.MatchRestOfSequence.target = target;
+    p->lineno = lineno;
+    p->col_offset = col_offset;
+    p->end_lineno = end_lineno;
+    p->end_col_offset = end_col_offset;
+    return p;
+}
+
+pattern_ty
+_PyAST_MatchAs(pattern_ty pattern, identifier target, int lineno, int
+               col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+{
+    pattern_ty p;
+    if (!target) {
+        PyErr_SetString(PyExc_ValueError,
+                        "field 'target' is required for MatchAs");
+        return NULL;
+    }
+    p = (pattern_ty)_PyArena_Malloc(arena, sizeof(*p));
+    if (!p)
+        return NULL;
+    p->kind = MatchAs_kind;
+    p->v.MatchAs.pattern = pattern;
+    p->v.MatchAs.target = target;
+    p->lineno = lineno;
+    p->col_offset = col_offset;
+    p->end_lineno = end_lineno;
+    p->end_col_offset = end_col_offset;
+    return p;
+}
+
+pattern_ty
+_PyAST_MatchOr(asdl_pattern_seq * patterns, int lineno, int col_offset, int
+               end_lineno, int end_col_offset, PyArena *arena)
+{
+    pattern_ty p;
+    p = (pattern_ty)_PyArena_Malloc(arena, sizeof(*p));
+    if (!p)
+        return NULL;
+    p->kind = MatchOr_kind;
+    p->v.MatchOr.patterns = patterns;
+    p->lineno = lineno;
+    p->col_offset = col_offset;
+    p->end_lineno = end_lineno;
+    p->end_col_offset = end_col_offset;
     return p;
 }
 
@@ -4410,32 +4646,6 @@ ast2obj_expr(struct ast_state *state, void* _o)
             goto failed;
         Py_DECREF(value);
         break;
-    case MatchAs_kind:
-        tp = (PyTypeObject *)state->MatchAs_type;
-        result = PyType_GenericNew(tp, NULL, NULL);
-        if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.MatchAs.pattern);
-        if (!value) goto failed;
-        if (PyObject_SetAttr(result, state->pattern, value) == -1)
-            goto failed;
-        Py_DECREF(value);
-        value = ast2obj_identifier(state, o->v.MatchAs.name);
-        if (!value) goto failed;
-        if (PyObject_SetAttr(result, state->name, value) == -1)
-            goto failed;
-        Py_DECREF(value);
-        break;
-    case MatchOr_kind:
-        tp = (PyTypeObject *)state->MatchOr_type;
-        result = PyType_GenericNew(tp, NULL, NULL);
-        if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.MatchOr.patterns,
-                             ast2obj_expr);
-        if (!value) goto failed;
-        if (PyObject_SetAttr(result, state->patterns, value) == -1)
-            goto failed;
-        Py_DECREF(value);
-        break;
     }
     value = ast2obj_int(state, o->lineno);
     if (!value) goto failed;
@@ -4935,7 +5145,7 @@ ast2obj_match_case(struct ast_state *state, void* _o)
     tp = (PyTypeObject *)state->match_case_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_expr(state, o->pattern);
+    value = ast2obj_pattern(state, o->pattern);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->pattern, value) == -1)
         goto failed;
@@ -4948,6 +5158,161 @@ ast2obj_match_case(struct ast_state *state, void* _o)
     value = ast2obj_list(state, (asdl_seq*)o->body, ast2obj_stmt);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->body, value) == -1)
+        goto failed;
+    Py_DECREF(value);
+    return result;
+failed:
+    Py_XDECREF(value);
+    Py_XDECREF(result);
+    return NULL;
+}
+
+PyObject*
+ast2obj_pattern(struct ast_state *state, void* _o)
+{
+    pattern_ty o = (pattern_ty)_o;
+    PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
+    if (!o) {
+        Py_RETURN_NONE;
+    }
+    switch (o->kind) {
+    case MatchAlways_kind:
+        tp = (PyTypeObject *)state->MatchAlways_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
+        if (!result) goto failed;
+        break;
+    case MatchValue_kind:
+        tp = (PyTypeObject *)state->MatchValue_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
+        if (!result) goto failed;
+        value = ast2obj_expr(state, o->v.MatchValue.value);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->value, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        break;
+    case MatchConstant_kind:
+        tp = (PyTypeObject *)state->MatchConstant_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
+        if (!result) goto failed;
+        value = ast2obj_constant(state, o->v.MatchConstant.value);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->value, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        break;
+    case MatchSequence_kind:
+        tp = (PyTypeObject *)state->MatchSequence_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
+        if (!result) goto failed;
+        value = ast2obj_list(state, (asdl_seq*)o->v.MatchSequence.patterns,
+                             ast2obj_pattern);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->patterns, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        break;
+    case MatchMapping_kind:
+        tp = (PyTypeObject *)state->MatchMapping_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
+        if (!result) goto failed;
+        value = ast2obj_list(state, (asdl_seq*)o->v.MatchMapping.keys,
+                             ast2obj_expr);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->keys, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        value = ast2obj_list(state, (asdl_seq*)o->v.MatchMapping.patterns,
+                             ast2obj_pattern);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->patterns, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        break;
+    case MatchClass_kind:
+        tp = (PyTypeObject *)state->MatchClass_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
+        if (!result) goto failed;
+        value = ast2obj_expr(state, o->v.MatchClass.cls);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->cls, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        value = ast2obj_list(state, (asdl_seq*)o->v.MatchClass.patterns,
+                             ast2obj_pattern);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->patterns, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        value = ast2obj_list(state, (asdl_seq*)o->v.MatchClass.extra_attrs,
+                             ast2obj_identifier);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->extra_attrs, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        value = ast2obj_list(state, (asdl_seq*)o->v.MatchClass.extra_patterns,
+                             ast2obj_pattern);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->extra_patterns, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        break;
+    case MatchRestOfSequence_kind:
+        tp = (PyTypeObject *)state->MatchRestOfSequence_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
+        if (!result) goto failed;
+        value = ast2obj_identifier(state, o->v.MatchRestOfSequence.target);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->target, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        break;
+    case MatchAs_kind:
+        tp = (PyTypeObject *)state->MatchAs_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
+        if (!result) goto failed;
+        value = ast2obj_pattern(state, o->v.MatchAs.pattern);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->pattern, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        value = ast2obj_identifier(state, o->v.MatchAs.target);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->target, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        break;
+    case MatchOr_kind:
+        tp = (PyTypeObject *)state->MatchOr_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
+        if (!result) goto failed;
+        value = ast2obj_list(state, (asdl_seq*)o->v.MatchOr.patterns,
+                             ast2obj_pattern);
+        if (!value) goto failed;
+        if (PyObject_SetAttr(result, state->patterns, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        break;
+    }
+    value = ast2obj_int(state, o->lineno);
+    if (!value) goto failed;
+    if (PyObject_SetAttr(result, state->lineno, value) < 0)
+        goto failed;
+    Py_DECREF(value);
+    value = ast2obj_int(state, o->col_offset);
+    if (!value) goto failed;
+    if (PyObject_SetAttr(result, state->col_offset, value) < 0)
+        goto failed;
+    Py_DECREF(value);
+    value = ast2obj_int(state, o->end_lineno);
+    if (!value) goto failed;
+    if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
+        goto failed;
+    Py_DECREF(value);
+    value = ast2obj_int(state, o->end_col_offset);
+    if (!value) goto failed;
+    if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -8689,92 +9054,6 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = state->MatchAs_type;
-    isinstance = PyObject_IsInstance(obj, tp);
-    if (isinstance == -1) {
-        return 1;
-    }
-    if (isinstance) {
-        expr_ty pattern;
-        identifier name;
-
-        if (_PyObject_LookupAttr(obj, state->pattern, &tmp) < 0) {
-            return 1;
-        }
-        if (tmp == NULL) {
-            PyErr_SetString(PyExc_TypeError, "required field \"pattern\" missing from MatchAs");
-            return 1;
-        }
-        else {
-            int res;
-            res = obj2ast_expr(state, tmp, &pattern, arena);
-            if (res != 0) goto failed;
-            Py_CLEAR(tmp);
-        }
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
-            return 1;
-        }
-        if (tmp == NULL) {
-            PyErr_SetString(PyExc_TypeError, "required field \"name\" missing from MatchAs");
-            return 1;
-        }
-        else {
-            int res;
-            res = obj2ast_identifier(state, tmp, &name, arena);
-            if (res != 0) goto failed;
-            Py_CLEAR(tmp);
-        }
-        *out = _PyAST_MatchAs(pattern, name, lineno, col_offset, end_lineno,
-                              end_col_offset, arena);
-        if (*out == NULL) goto failed;
-        return 0;
-    }
-    tp = state->MatchOr_type;
-    isinstance = PyObject_IsInstance(obj, tp);
-    if (isinstance == -1) {
-        return 1;
-    }
-    if (isinstance) {
-        asdl_expr_seq* patterns;
-
-        if (_PyObject_LookupAttr(obj, state->patterns, &tmp) < 0) {
-            return 1;
-        }
-        if (tmp == NULL) {
-            PyErr_SetString(PyExc_TypeError, "required field \"patterns\" missing from MatchOr");
-            return 1;
-        }
-        else {
-            int res;
-            Py_ssize_t len;
-            Py_ssize_t i;
-            if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "MatchOr field \"patterns\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
-                goto failed;
-            }
-            len = PyList_GET_SIZE(tmp);
-            patterns = _Py_asdl_expr_seq_new(len, arena);
-            if (patterns == NULL) goto failed;
-            for (i = 0; i < len; i++) {
-                expr_ty val;
-                PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
-                Py_INCREF(tmp2);
-                res = obj2ast_expr(state, tmp2, &val, arena);
-                Py_DECREF(tmp2);
-                if (res != 0) goto failed;
-                if (len != PyList_GET_SIZE(tmp)) {
-                    PyErr_SetString(PyExc_RuntimeError, "MatchOr field \"patterns\" changed size during iteration");
-                    goto failed;
-                }
-                asdl_seq_SET(patterns, i, val);
-            }
-            Py_CLEAR(tmp);
-        }
-        *out = _PyAST_MatchOr(patterns, lineno, col_offset, end_lineno,
-                              end_col_offset, arena);
-        if (*out == NULL) goto failed;
-        return 0;
-    }
 
     PyErr_Format(PyExc_TypeError, "expected some sort of expr, but got %R", obj);
     failed:
@@ -9897,7 +10176,7 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
                    PyArena* arena)
 {
     PyObject* tmp = NULL;
-    expr_ty pattern;
+    pattern_ty pattern;
     expr_ty guard;
     asdl_stmt_seq* body;
 
@@ -9910,7 +10189,7 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
     }
     else {
         int res;
-        res = obj2ast_expr(state, tmp, &pattern, arena);
+        res = obj2ast_pattern(state, tmp, &pattern, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9963,6 +10242,513 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
     *out = _PyAST_match_case(pattern, guard, body, arena);
     return 0;
 failed:
+    Py_XDECREF(tmp);
+    return 1;
+}
+
+int
+obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
+                PyArena* arena)
+{
+    int isinstance;
+
+    PyObject *tmp = NULL;
+    PyObject *tp;
+    int lineno;
+    int col_offset;
+    int end_lineno;
+    int end_col_offset;
+
+    if (obj == Py_None) {
+        *out = NULL;
+        return 0;
+    }
+    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"lineno\" missing from pattern");
+        return 1;
+    }
+    else {
+        int res;
+        res = obj2ast_int(state, tmp, &lineno, arena);
+        if (res != 0) goto failed;
+        Py_CLEAR(tmp);
+    }
+    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"col_offset\" missing from pattern");
+        return 1;
+    }
+    else {
+        int res;
+        res = obj2ast_int(state, tmp, &col_offset, arena);
+        if (res != 0) goto failed;
+        Py_CLEAR(tmp);
+    }
+    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL || tmp == Py_None) {
+        Py_CLEAR(tmp);
+        end_lineno = 0;
+    }
+    else {
+        int res;
+        res = obj2ast_int(state, tmp, &end_lineno, arena);
+        if (res != 0) goto failed;
+        Py_CLEAR(tmp);
+    }
+    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL || tmp == Py_None) {
+        Py_CLEAR(tmp);
+        end_col_offset = 0;
+    }
+    else {
+        int res;
+        res = obj2ast_int(state, tmp, &end_col_offset, arena);
+        if (res != 0) goto failed;
+        Py_CLEAR(tmp);
+    }
+    tp = state->MatchAlways_type;
+    isinstance = PyObject_IsInstance(obj, tp);
+    if (isinstance == -1) {
+        return 1;
+    }
+    if (isinstance) {
+
+        *out = _PyAST_MatchAlways(lineno, col_offset, end_lineno,
+                                  end_col_offset, arena);
+        if (*out == NULL) goto failed;
+        return 0;
+    }
+    tp = state->MatchValue_type;
+    isinstance = PyObject_IsInstance(obj, tp);
+    if (isinstance == -1) {
+        return 1;
+    }
+    if (isinstance) {
+        expr_ty value;
+
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from MatchValue");
+            return 1;
+        }
+        else {
+            int res;
+            res = obj2ast_expr(state, tmp, &value, arena);
+            if (res != 0) goto failed;
+            Py_CLEAR(tmp);
+        }
+        *out = _PyAST_MatchValue(value, lineno, col_offset, end_lineno,
+                                 end_col_offset, arena);
+        if (*out == NULL) goto failed;
+        return 0;
+    }
+    tp = state->MatchConstant_type;
+    isinstance = PyObject_IsInstance(obj, tp);
+    if (isinstance == -1) {
+        return 1;
+    }
+    if (isinstance) {
+        constant value;
+
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from MatchConstant");
+            return 1;
+        }
+        else {
+            int res;
+            res = obj2ast_constant(state, tmp, &value, arena);
+            if (res != 0) goto failed;
+            Py_CLEAR(tmp);
+        }
+        *out = _PyAST_MatchConstant(value, lineno, col_offset, end_lineno,
+                                    end_col_offset, arena);
+        if (*out == NULL) goto failed;
+        return 0;
+    }
+    tp = state->MatchSequence_type;
+    isinstance = PyObject_IsInstance(obj, tp);
+    if (isinstance == -1) {
+        return 1;
+    }
+    if (isinstance) {
+        asdl_pattern_seq* patterns;
+
+        if (_PyObject_LookupAttr(obj, state->patterns, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"patterns\" missing from MatchSequence");
+            return 1;
+        }
+        else {
+            int res;
+            Py_ssize_t len;
+            Py_ssize_t i;
+            if (!PyList_Check(tmp)) {
+                PyErr_Format(PyExc_TypeError, "MatchSequence field \"patterns\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
+                goto failed;
+            }
+            len = PyList_GET_SIZE(tmp);
+            patterns = _Py_asdl_pattern_seq_new(len, arena);
+            if (patterns == NULL) goto failed;
+            for (i = 0; i < len; i++) {
+                pattern_ty val;
+                PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
+                Py_INCREF(tmp2);
+                res = obj2ast_pattern(state, tmp2, &val, arena);
+                Py_DECREF(tmp2);
+                if (res != 0) goto failed;
+                if (len != PyList_GET_SIZE(tmp)) {
+                    PyErr_SetString(PyExc_RuntimeError, "MatchSequence field \"patterns\" changed size during iteration");
+                    goto failed;
+                }
+                asdl_seq_SET(patterns, i, val);
+            }
+            Py_CLEAR(tmp);
+        }
+        *out = _PyAST_MatchSequence(patterns, lineno, col_offset, end_lineno,
+                                    end_col_offset, arena);
+        if (*out == NULL) goto failed;
+        return 0;
+    }
+    tp = state->MatchMapping_type;
+    isinstance = PyObject_IsInstance(obj, tp);
+    if (isinstance == -1) {
+        return 1;
+    }
+    if (isinstance) {
+        asdl_expr_seq* keys;
+        asdl_pattern_seq* patterns;
+
+        if (_PyObject_LookupAttr(obj, state->keys, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"keys\" missing from MatchMapping");
+            return 1;
+        }
+        else {
+            int res;
+            Py_ssize_t len;
+            Py_ssize_t i;
+            if (!PyList_Check(tmp)) {
+                PyErr_Format(PyExc_TypeError, "MatchMapping field \"keys\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
+                goto failed;
+            }
+            len = PyList_GET_SIZE(tmp);
+            keys = _Py_asdl_expr_seq_new(len, arena);
+            if (keys == NULL) goto failed;
+            for (i = 0; i < len; i++) {
+                expr_ty val;
+                PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
+                Py_INCREF(tmp2);
+                res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_DECREF(tmp2);
+                if (res != 0) goto failed;
+                if (len != PyList_GET_SIZE(tmp)) {
+                    PyErr_SetString(PyExc_RuntimeError, "MatchMapping field \"keys\" changed size during iteration");
+                    goto failed;
+                }
+                asdl_seq_SET(keys, i, val);
+            }
+            Py_CLEAR(tmp);
+        }
+        if (_PyObject_LookupAttr(obj, state->patterns, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"patterns\" missing from MatchMapping");
+            return 1;
+        }
+        else {
+            int res;
+            Py_ssize_t len;
+            Py_ssize_t i;
+            if (!PyList_Check(tmp)) {
+                PyErr_Format(PyExc_TypeError, "MatchMapping field \"patterns\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
+                goto failed;
+            }
+            len = PyList_GET_SIZE(tmp);
+            patterns = _Py_asdl_pattern_seq_new(len, arena);
+            if (patterns == NULL) goto failed;
+            for (i = 0; i < len; i++) {
+                pattern_ty val;
+                PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
+                Py_INCREF(tmp2);
+                res = obj2ast_pattern(state, tmp2, &val, arena);
+                Py_DECREF(tmp2);
+                if (res != 0) goto failed;
+                if (len != PyList_GET_SIZE(tmp)) {
+                    PyErr_SetString(PyExc_RuntimeError, "MatchMapping field \"patterns\" changed size during iteration");
+                    goto failed;
+                }
+                asdl_seq_SET(patterns, i, val);
+            }
+            Py_CLEAR(tmp);
+        }
+        *out = _PyAST_MatchMapping(keys, patterns, lineno, col_offset,
+                                   end_lineno, end_col_offset, arena);
+        if (*out == NULL) goto failed;
+        return 0;
+    }
+    tp = state->MatchClass_type;
+    isinstance = PyObject_IsInstance(obj, tp);
+    if (isinstance == -1) {
+        return 1;
+    }
+    if (isinstance) {
+        expr_ty cls;
+        asdl_pattern_seq* patterns;
+        asdl_identifier_seq* extra_attrs;
+        asdl_pattern_seq* extra_patterns;
+
+        if (_PyObject_LookupAttr(obj, state->cls, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"cls\" missing from MatchClass");
+            return 1;
+        }
+        else {
+            int res;
+            res = obj2ast_expr(state, tmp, &cls, arena);
+            if (res != 0) goto failed;
+            Py_CLEAR(tmp);
+        }
+        if (_PyObject_LookupAttr(obj, state->patterns, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"patterns\" missing from MatchClass");
+            return 1;
+        }
+        else {
+            int res;
+            Py_ssize_t len;
+            Py_ssize_t i;
+            if (!PyList_Check(tmp)) {
+                PyErr_Format(PyExc_TypeError, "MatchClass field \"patterns\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
+                goto failed;
+            }
+            len = PyList_GET_SIZE(tmp);
+            patterns = _Py_asdl_pattern_seq_new(len, arena);
+            if (patterns == NULL) goto failed;
+            for (i = 0; i < len; i++) {
+                pattern_ty val;
+                PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
+                Py_INCREF(tmp2);
+                res = obj2ast_pattern(state, tmp2, &val, arena);
+                Py_DECREF(tmp2);
+                if (res != 0) goto failed;
+                if (len != PyList_GET_SIZE(tmp)) {
+                    PyErr_SetString(PyExc_RuntimeError, "MatchClass field \"patterns\" changed size during iteration");
+                    goto failed;
+                }
+                asdl_seq_SET(patterns, i, val);
+            }
+            Py_CLEAR(tmp);
+        }
+        if (_PyObject_LookupAttr(obj, state->extra_attrs, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"extra_attrs\" missing from MatchClass");
+            return 1;
+        }
+        else {
+            int res;
+            Py_ssize_t len;
+            Py_ssize_t i;
+            if (!PyList_Check(tmp)) {
+                PyErr_Format(PyExc_TypeError, "MatchClass field \"extra_attrs\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
+                goto failed;
+            }
+            len = PyList_GET_SIZE(tmp);
+            extra_attrs = _Py_asdl_identifier_seq_new(len, arena);
+            if (extra_attrs == NULL) goto failed;
+            for (i = 0; i < len; i++) {
+                identifier val;
+                PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
+                Py_INCREF(tmp2);
+                res = obj2ast_identifier(state, tmp2, &val, arena);
+                Py_DECREF(tmp2);
+                if (res != 0) goto failed;
+                if (len != PyList_GET_SIZE(tmp)) {
+                    PyErr_SetString(PyExc_RuntimeError, "MatchClass field \"extra_attrs\" changed size during iteration");
+                    goto failed;
+                }
+                asdl_seq_SET(extra_attrs, i, val);
+            }
+            Py_CLEAR(tmp);
+        }
+        if (_PyObject_LookupAttr(obj, state->extra_patterns, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"extra_patterns\" missing from MatchClass");
+            return 1;
+        }
+        else {
+            int res;
+            Py_ssize_t len;
+            Py_ssize_t i;
+            if (!PyList_Check(tmp)) {
+                PyErr_Format(PyExc_TypeError, "MatchClass field \"extra_patterns\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
+                goto failed;
+            }
+            len = PyList_GET_SIZE(tmp);
+            extra_patterns = _Py_asdl_pattern_seq_new(len, arena);
+            if (extra_patterns == NULL) goto failed;
+            for (i = 0; i < len; i++) {
+                pattern_ty val;
+                PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
+                Py_INCREF(tmp2);
+                res = obj2ast_pattern(state, tmp2, &val, arena);
+                Py_DECREF(tmp2);
+                if (res != 0) goto failed;
+                if (len != PyList_GET_SIZE(tmp)) {
+                    PyErr_SetString(PyExc_RuntimeError, "MatchClass field \"extra_patterns\" changed size during iteration");
+                    goto failed;
+                }
+                asdl_seq_SET(extra_patterns, i, val);
+            }
+            Py_CLEAR(tmp);
+        }
+        *out = _PyAST_MatchClass(cls, patterns, extra_attrs, extra_patterns,
+                                 lineno, col_offset, end_lineno,
+                                 end_col_offset, arena);
+        if (*out == NULL) goto failed;
+        return 0;
+    }
+    tp = state->MatchRestOfSequence_type;
+    isinstance = PyObject_IsInstance(obj, tp);
+    if (isinstance == -1) {
+        return 1;
+    }
+    if (isinstance) {
+        identifier target;
+
+        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            target = NULL;
+        }
+        else {
+            int res;
+            res = obj2ast_identifier(state, tmp, &target, arena);
+            if (res != 0) goto failed;
+            Py_CLEAR(tmp);
+        }
+        *out = _PyAST_MatchRestOfSequence(target, lineno, col_offset,
+                                          end_lineno, end_col_offset, arena);
+        if (*out == NULL) goto failed;
+        return 0;
+    }
+    tp = state->MatchAs_type;
+    isinstance = PyObject_IsInstance(obj, tp);
+    if (isinstance == -1) {
+        return 1;
+    }
+    if (isinstance) {
+        pattern_ty pattern;
+        identifier target;
+
+        if (_PyObject_LookupAttr(obj, state->pattern, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            pattern = NULL;
+        }
+        else {
+            int res;
+            res = obj2ast_pattern(state, tmp, &pattern, arena);
+            if (res != 0) goto failed;
+            Py_CLEAR(tmp);
+        }
+        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from MatchAs");
+            return 1;
+        }
+        else {
+            int res;
+            res = obj2ast_identifier(state, tmp, &target, arena);
+            if (res != 0) goto failed;
+            Py_CLEAR(tmp);
+        }
+        *out = _PyAST_MatchAs(pattern, target, lineno, col_offset, end_lineno,
+                              end_col_offset, arena);
+        if (*out == NULL) goto failed;
+        return 0;
+    }
+    tp = state->MatchOr_type;
+    isinstance = PyObject_IsInstance(obj, tp);
+    if (isinstance == -1) {
+        return 1;
+    }
+    if (isinstance) {
+        asdl_pattern_seq* patterns;
+
+        if (_PyObject_LookupAttr(obj, state->patterns, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"patterns\" missing from MatchOr");
+            return 1;
+        }
+        else {
+            int res;
+            Py_ssize_t len;
+            Py_ssize_t i;
+            if (!PyList_Check(tmp)) {
+                PyErr_Format(PyExc_TypeError, "MatchOr field \"patterns\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
+                goto failed;
+            }
+            len = PyList_GET_SIZE(tmp);
+            patterns = _Py_asdl_pattern_seq_new(len, arena);
+            if (patterns == NULL) goto failed;
+            for (i = 0; i < len; i++) {
+                pattern_ty val;
+                PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
+                Py_INCREF(tmp2);
+                res = obj2ast_pattern(state, tmp2, &val, arena);
+                Py_DECREF(tmp2);
+                if (res != 0) goto failed;
+                if (len != PyList_GET_SIZE(tmp)) {
+                    PyErr_SetString(PyExc_RuntimeError, "MatchOr field \"patterns\" changed size during iteration");
+                    goto failed;
+                }
+                asdl_seq_SET(patterns, i, val);
+            }
+            Py_CLEAR(tmp);
+        }
+        *out = _PyAST_MatchOr(patterns, lineno, col_offset, end_lineno,
+                              end_col_offset, arena);
+        if (*out == NULL) goto failed;
+        return 0;
+    }
+
+    PyErr_Format(PyExc_TypeError, "expected some sort of pattern, but got %R", obj);
+    failed:
     Py_XDECREF(tmp);
     return 1;
 }
@@ -10230,12 +11016,6 @@ astmodule_exec(PyObject *m)
     if (PyModule_AddObjectRef(m, "Slice", state->Slice_type) < 0) {
         return -1;
     }
-    if (PyModule_AddObjectRef(m, "MatchAs", state->MatchAs_type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "MatchOr", state->MatchOr_type) < 0) {
-        return -1;
-    }
     if (PyModule_AddObjectRef(m, "expr_context", state->expr_context_type) < 0)
         {
         return -1;
@@ -10376,6 +11156,40 @@ astmodule_exec(PyObject *m)
         return -1;
     }
     if (PyModule_AddObjectRef(m, "match_case", state->match_case_type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "pattern", state->pattern_type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MatchAlways", state->MatchAlways_type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MatchValue", state->MatchValue_type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MatchConstant", state->MatchConstant_type) <
+        0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MatchSequence", state->MatchSequence_type) <
+        0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MatchMapping", state->MatchMapping_type) < 0)
+        {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MatchClass", state->MatchClass_type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MatchRestOfSequence",
+        state->MatchRestOfSequence_type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MatchAs", state->MatchAs_type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MatchOr", state->MatchOr_type) < 0) {
         return -1;
     }
     if (PyModule_AddObjectRef(m, "type_ignore", state->type_ignore_type) < 0) {


### PR DESCRIPTION
* Separates "pattern" and "expr" nodes in AST
* AST node names are derived from the AST proposed
  in PEP 642, except that MatchValue always matches
  by equality and a separate MatchConstant node is
  defined for matching by identity
* Grammar definition has been updated to emit the
  newly defined AST nodes
* TODO: update code generator to consume new nodes
* TODO: update AST validator to consume new nodes
* TODO: update AST unparser to consume new nodes
